### PR TITLE
Make sure both 'settings' and 'builders' are in the YAML.

### DIFF
--- a/rosdoc2/verbs/build/parse_rosdoc2_yaml.py
+++ b/rosdoc2/verbs/build/parse_rosdoc2_yaml.py
@@ -61,8 +61,23 @@ def parse_rosdoc2_yaml(yaml_string, build_context):
             f"Error parsing file '{file_name}', in the second section, "
             f"expected something like dict{{settings: <tool settings>, builders: <builders>}}, "
             f"got a '{type(config)}' instead")
-    settings_dict = config.get('settings', {})
-    builders_dict = config.get('builders', {})
+
+    if 'settings' not in config:
+        raise ValueError(
+            f"Error parsing file '{file_name}', in the second section, "
+            f"expected a 'settings' key")
+    settings_dict = config['settings']
+    if not isinstance(settings_dict, dict):
+        raise ValueError(
+            f"Error parsing file '{file_name}', in the second section, value 'settings', "
+            f"expected a dict{{output_dir: build_settings, ...}}, "
+            f"got a '{type(builders_dict)}' instead")
+
+    if 'builders' not in config:
+        raise ValueError(
+            f"Error parsing file '{file_name}', in the second section, "
+            f"expected a 'builders' key")
+    builders_dict = config['builders']
     if not isinstance(builders_dict, dict):
         raise ValueError(
             f"Error parsing file '{file_name}', in the second section, value 'builders', "


### PR DESCRIPTION
That is, don't fall back to empty defaults for them.  This
is important in case users provide their own YAML configuration,
but have a typo in them (like 'biulders' instead of 'builders').
With the default of an empty dict, the builders would just be
skipped completely, and could lead to hard-to-debug issues.
At least with this PR it would be louder.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@wjwwood @tfoote This seems fairly harmless to me, but an opinion on whether this is the right way to go is appreciated.