### PR TITLE
Change the YAML builder configuration arguments.

### DIFF
--- a/rosdoc2/verbs/build/builder.py
+++ b/rosdoc2/verbs/build/builder.py
@@ -22,15 +22,18 @@ class Builder(object):
     """
     Base class for all builders, which just takes care of some boilerplate logic.
     """
-    def __init__(self, builder_entry_dictionary, output_dir, build_context):
-        if 'builder' not in builder_entry_dictionary:
-            raise RuntimeError("Error entry without 'builder' field found")
-        self.builder_type = builder_entry_dictionary['builder']
+    def __init__(self, builder_name, builder_entry_dictionary, build_context):
+        self.builder_type = builder_name
+
         if 'name' not in builder_entry_dictionary:
             raise RuntimeError("Error entry without 'name' field found")
         self.name = builder_entry_dictionary['name']
+
+        if 'output_dir' not in builder_entry_dictionary:
+            raise RuntimeError("Error entry without 'output_dir' field found")
+        self.output_dir = builder_entry_dictionary['output_dir']
+
         self.builder_entry_dictionary = builder_entry_dictionary
-        self.output_dir = output_dir
         self.build_context = build_context
 
     def build(self, *, doc_build_folder, output_staging_directory):

--- a/rosdoc2/verbs/build/builders/__init__.py
+++ b/rosdoc2/verbs/build/builders/__init__.py
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 
-def create_builder_by_name(builder_name, *, builder_dict, output_dir, build_context):
+def create_builder_by_name(builder_name, *, builder_dict, build_context):
     # TODO(wjwwood): make this an extension point
     builders = {
         'doxygen': DoxygenBuilder,
@@ -33,4 +33,4 @@ def create_builder_by_name(builder_name, *, builder_dict, output_dir, build_cont
         builder_names = ', '.join(list(builders.keys()))
         raise RuntimeError(
             f"Error unknown builder '{builder_name}', supported builders: [{builder_names}]")
-    return builder_class(builder_dict, output_dir, build_context)
+    return builder_class(builder_name, builder_dict, build_context)

--- a/rosdoc2/verbs/build/builders/doxygen_builder.py
+++ b/rosdoc2/verbs/build/builders/doxygen_builder.py
@@ -69,10 +69,10 @@ class DoxygenBuilder(Builder):
     - extra_doxyfile_statements (list[str]) (optional)
       - extra doxyfile statements which would be added after the default, or user, doxyfile
     """
-    def __init__(self, builder_entry_dictionary, output_dir, build_context):
+    def __init__(self, builder_name, builder_entry_dictionary, build_context):
         super(DoxygenBuilder, self).__init__(
+            builder_name,
             builder_entry_dictionary,
-            output_dir,
             build_context)
 
         assert self.builder_type == 'doxygen'
@@ -84,7 +84,7 @@ class DoxygenBuilder(Builder):
 
         # Process keys.
         for key, value in builder_entry_dictionary.items():
-            if key in ['name', 'builder']:
+            if key in ['name', 'output_dir']:
                 continue
             if key == 'doxyfile':
                 config_file_dir = os.path.dirname(configuration_file_path)

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -280,10 +280,10 @@ class SphinxBuilder(Builder):
       - directory containing the Sphinx project, i.e. the `conf.py`, the setting
         you would pass to sphinx-build as SOURCEDIR. Defaults to `doc`.
     """
-    def __init__(self, builder_entry_dictionary, output_dir, build_context):
+    def __init__(self, builder_name, builder_entry_dictionary, build_context):
         super(SphinxBuilder, self).__init__(
+            builder_name,
             builder_entry_dictionary,
-            output_dir,
             build_context)
 
         assert self.builder_type == 'sphinx'
@@ -299,7 +299,7 @@ class SphinxBuilder(Builder):
 
         # Process keys.
         for key, value in builder_entry_dictionary.items():
-            if key in ['name', 'builder']:
+            if key in ['name', 'output_dir']:
                 continue
             if key == 'sphinx_sourcedir':
                 sphinx_sourcedir = os.path.join(configuration_file_dir, value)

--- a/rosdoc2/verbs/build/inspect_package_for_settings.py
+++ b/rosdoc2/verbs/build/inspect_package_for_settings.py
@@ -46,21 +46,24 @@ settings:
     generate_package_index: true
 builders:
     ## Each stanza represents a separate build step, performed by a specific 'builder'.
-    ## The key of each stanza the output subdirectory for that builder instance,
-    ## and is relative to the '--output-directory' specified to the tool.
+    ## The key of each stanza is the builder to use; this must be one of the
+    ## available builders.
     ## The value of each stanza is a dictionary of settings for the builder that
     ## outputs to that directory.
-    ## Required keys in the settings dictionary are 'builder' which determines the
-    ## builder executed there, and 'name' which is used when referencing the built
-    ## docs from the index.
-    'generated/doxygen':
-        builder: doxygen
-        name: '{package_name} Public C/C++ API'
-    '':
-        builder: sphinx
-        name: '{package_name}'
+    ## Required keys in the settings dictionary are:
+    ##  * 'output_dir' - determines the output subdirectory for that builder instance relative to --output-directory
+    ##  * 'name' - used when referencing the built docs from the index.
+
+    - doxygen: {
+        name: '{package_name} Public C/C++ API',
+        output_dir: 'generated/doxygen'
+    }
+    - sphinx: {
+        name: '{package_name}',
         ## This path is relative to output staging.
-        doxygen_xml_directory: 'generated/doxygen/xml'
+        doxygen_xml_directory: 'generated/doxygen/xml',
+        output_dir: ''
+    }
 """
 
 

--- a/rosdoc2/verbs/build/inspect_package_for_settings.py
+++ b/rosdoc2/verbs/build/inspect_package_for_settings.py
@@ -54,16 +54,16 @@ builders:
     ##  * 'output_dir' - determines the output subdirectory for that builder instance relative to --output-directory
     ##  * 'name' - used when referencing the built docs from the index.
 
-    - doxygen: {
+    - doxygen: {{
         name: '{package_name} Public C/C++ API',
         output_dir: 'generated/doxygen'
-    }
-    - sphinx: {
+    }}
+    - sphinx: {{
         name: '{package_name}',
         ## This path is relative to output staging.
         doxygen_xml_directory: 'generated/doxygen/xml',
         output_dir: ''
-    }
+    }}
 """
 
 

--- a/rosdoc2/verbs/build/parse_rosdoc2_yaml.py
+++ b/rosdoc2/verbs/build/parse_rosdoc2_yaml.py
@@ -73,7 +73,7 @@ def parse_rosdoc2_yaml(yaml_string, build_context):
         if len(builder) != 1:
             raise ValueError(
                 f"Error parsing file '{file_name}', in the second section, each builder "
-                f"must have a 'type'")
+                f"must have exactly one key (which is the type of builder to use)")
         builder_name = next(iter(builder))
         builders.append(create_builder_by_name(builder_name, builder_dict=builder[builder_name], build_context=build_context))
 

--- a/rosdoc2/verbs/build/parse_rosdoc2_yaml.py
+++ b/rosdoc2/verbs/build/parse_rosdoc2_yaml.py
@@ -17,22 +17,6 @@ import yaml
 from .builders import create_builder_by_name
 
 
-def parse_builder_entry(output_directory, builder_dict, build_context):
-    """
-    Parse a single builder dictionary entry.
-    """
-    if 'builder' not in builder_dict:
-        keys = ', '.join(list(builder_dict.keys()))
-        raise ValueError(
-            f"Error parsing file '{build_context.configuration_file_path}', "
-            f"expected to find a 'builder' key but found only '[{keys}]'")
-    return create_builder_by_name(
-        builder_dict['builder'],
-        builder_dict=builder_dict,
-        output_dir=output_directory,
-        build_context=build_context)
-
-
 def parse_rosdoc2_yaml(yaml_string, build_context):
     """
     Parse a rosdoc2.yaml configuration string, returning it as a tuple of settings and builders.
@@ -77,14 +61,20 @@ def parse_rosdoc2_yaml(yaml_string, build_context):
         raise ValueError(
             f"Error parsing file '{file_name}', in the second section, "
             f"expected a 'builders' key")
-    builders_dict = config['builders']
-    if not isinstance(builders_dict, dict):
+    builders_list = config['builders']
+    if not isinstance(builders_list, list):
         raise ValueError(
             f"Error parsing file '{file_name}', in the second section, value 'builders', "
-            f"expected a dict{{output_dir: build_settings, ...}}, "
-            f"got a '{type(builders_dict)}' instead")
+            f"expected a list of builders, "
+            f"got a '{type(builders_list)}' instead")
 
     builders = []
-    for output_directory, entry in builders_dict.items():
-        builders.append(parse_builder_entry(output_directory, entry, build_context))
+    for builder in builders_list:
+        if len(builder) != 1:
+            raise ValueError(
+                f"Error parsing file '{file_name}', in the second section, each builder "
+                f"must have a 'type'")
+        builder_name = next(iter(builder))
+        builders.append(create_builder_by_name(builder_name, builder_dict=builder[builder_name], build_context=build_context))
+
     return (settings_dict, builders)


### PR DESCRIPTION
Make the builders a list, where the key for each one is the
type of builder and the values is a dictionary of required
and optional keys.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This may be the most important one that we agree on, since it fundamentally changes the configuration file that users provide (and thus it will be hard to change later).  Opinions welcome here.