### PR TITLE
Remove --{build,install}-directory arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ To generate the documentation for almost any ROS 2 package, first build the pack
 
 ```
 $ rosdoc2 build \
-  --build-directory ./build/my_package_name \
-  --install-directory ./install \
   --cross-reference-directory ./cross_reference \
   --output-directory ./doc_output \
   --package-path ./src/path/to/my_package_name

--- a/rosdoc2/verbs/build/impl.py
+++ b/rosdoc2/verbs/build/impl.py
@@ -58,18 +58,6 @@ def prepare_arguments(parser):
         help='path to the ROS package',
     )
     parser.add_argument(
-        '--build-directory',
-        '-b',
-        required=True,
-        help='build directory of the package',
-    )
-    parser.add_argument(
-        '--install-directory',
-        '-i',
-        required=True,
-        help='install directory of the package',
-    )
-    parser.add_argument(
         '--cross-reference-directory',
         '-c',
         required=True,
@@ -118,14 +106,6 @@ def main_impl(options):
         package = get_package(options.package_path)
     except Exception as e:
         sys.exit(f'Error: {e}')
-
-    # Check that the build directory exists.
-    if not os.path.exists(options.build_directory):
-        sys.exit(f"Error: given build directory '{options.build_directory}' does not exist")
-
-    # Check that the install directory exists.
-    if not os.path.exists(options.install_directory):
-        sys.exit(f"Error: given install directory '{options.install_directory}' does not exist")
 
     # Inspect package for additional settings, using defaults if none found.
     tool_settings, builders = inspect_package_for_settings(


### PR DESCRIPTION
As far as I can tell, they are unused at the moment.  Removing
them simplifies running the tool for end-users.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Any opinions on whether we need this or not is welcome.