### PR TITLE
enable automatic intersphinx mapping extension between packages

### DIFF
--- a/rosdoc2/verbs/build/builders/doxygen_builder.py
+++ b/rosdoc2/verbs/build/builders/doxygen_builder.py
@@ -230,6 +230,7 @@ class DoxygenBuilder(Builder):
             os.path.abspath(tag_file_name),
             os.path.abspath(destination)
         )
+
         # Create a tag.location.json file as well, so we can know the relative path to the root
         # of the doxygen content from the package's documentation root.
         data = {

--- a/rosdoc2/verbs/build/collect_inventory_files.py
+++ b/rosdoc2/verbs/build/collect_inventory_files.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import logging
 import os
+
+logger = logging.getLogger('rosdoc2')
 
 
 def collect_inventory_files(cross_reference_directory):
@@ -31,5 +35,18 @@ def collect_inventory_files(cross_reference_directory):
                     raise RuntimeError(
                         f"unexpectedly got duplicate tag file for package '{package_name}'"
                     )
-                inventory_files[package_name] = os.path.join(root, filename)
+                inventory_file_path = os.path.join(root, filename)
+                location_json_path = inventory_file_path + '.location.json'
+                if not os.path.exists(location_json_path):
+                    logger.warn(
+                        f"Ignoring tag file '{inventory_file_path}' because it lacks "
+                        f"a '.location.json' file.")
+                    continue
+                location_data = None
+                with open(location_json_path, 'r+') as f:
+                    location_data = json.loads(f.read())
+                inventory_files[package_name] = {
+                    'inventory_file': inventory_file_path,
+                    'location_data': location_data,
+                }
     return inventory_files

--- a/rosdoc2/verbs/build/impl.py
+++ b/rosdoc2/verbs/build/impl.py
@@ -22,7 +22,6 @@ from catkin_pkg.package import InvalidPackage
 from catkin_pkg.package import package_exists_at
 from catkin_pkg.package import parse_package
 
-from .collect_inventory_files import collect_inventory_files
 from .inspect_package_for_settings import inspect_package_for_settings
 from rosdoc2.slugify import slugify
 
@@ -135,9 +134,6 @@ def main_impl(options):
 
     # Create the cross reference directory if it doesn't exist.
     os.makedirs(os.path.join(options.cross_reference_directory, package.name), exist_ok=True)
-
-    # Collect Sphinx inventory files.
-    inventory_files = collect_inventory_files(options.cross_reference_directory)
 
     # Generate the doc build directory.
     package_doc_build_directory = os.path.join(options.doc_build_directory, package.name)


### PR DESCRIPTION
This is in the same fashion as the doxygen tag files, using a `.location.json` file along side the `objects.inv` to handle sphinx when it is in a subdirectory of the documentation output directory (not the default).