### PR TITLE
Switch to Read-the-docs theme.

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -88,8 +88,9 @@ if rosdoc2_settings.get('enable_exhale', True):
     }})
 
 if rosdoc2_settings.get('override_theme', True):
+    extensions.append('sphinx_rtd_theme')
+    html_theme = 'sphinx_rtd_theme'
     print(f"[rosdoc2] overriding theme to be '{{html_theme}}'", file=sys.stderr)
-    html_theme = 'classic'
 
 if rosdoc2_settings.get('automatically_extend_intersphinx_mapping', True):
     print(f"[rosdoc2] extending intersphinx mapping", file=sys.stderr)
@@ -171,7 +172,7 @@ master_doc = 'main'
 #
 ## rosdoc2 will override the theme, but you may set one here for running Sphinx
 ## without the rosdoc2 tool.
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -147,6 +147,7 @@ version = '{package_version_short}'
 ## If you add them manually rosdoc2 may still try to configure them.
 ## See the rosdoc2_settings below for some options on avoiding that.
 extensions = [
+    'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     pyyaml
     setuptools>=40.6.0
     sphinx
+    sphinx-rtd-theme
 packages = find:
 tests_require =
     flake8


### PR DESCRIPTION
This makes it consistent with the documentation hosted at
https://docs.ros.org/en/foxy

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

As we discussed earlier, switch to RTD theme.