### PR TITLE
Fix intersphinx generation.

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -322,7 +322,7 @@ class SphinxBuilder(Builder):
         intersphinx_mapping_extensions = [
             f"'{package_name}': "
             f"('{base_url}/{package_name}/{inventory_dict['location_data']['relative_root']}', "
-            f"'{os.path.abspath(inventory_dict['inventory_file'])}'),"
+            f"'{os.path.abspath(inventory_dict['inventory_file'])}')"
             for package_name, inventory_dict in inventory_files.items()
             # Exclude ourselves.
             if package_name != self.build_context.package.name


### PR DESCRIPTION
When you have more than 1 package in a repository, rosdoc2
will automatically generate intersphinx mappings between the
packages in the repository.  Unfortunately, there is a bug
where two commas get put into the entries, which means that
sphinx throws an "invalid syntax" warning when trying to parse
it.  Fix that here by removing the first one, and just rely
on the join() later on to add commas as appropriate.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>