### PR TITLE
Fix toctree warnings and render toctree in the HTML sidebar

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -228,7 +228,6 @@ C++ API
 .. toctree::
    :maxdepth: 2
 
-   README <api/program_listing_file_README.md.rst>
    api/library_root
    Full API <api/unabridged_api>
    File structure <api/unabridged_orphan>

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -170,6 +170,15 @@ master_doc = 'index'
 ## without the rosdoc2 tool.
 html_theme = 'sphinx_rtd_theme'
 
+html_theme_options = {{
+    # Toc options
+    'collapse_navigation': False,
+    'sticky_navigation': True,
+    'navigation_depth': -1,
+    'includehidden': True,
+    'titles_only': False,
+}}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
@@ -216,9 +225,13 @@ index_rst_template = """\
 C++ API
 =======
 
-:doc:`api/library_root`
+.. toctree::
+   :maxdepth: 2
 
-.. doxygenindex::
+   README <api/program_listing_file_README.md.rst>
+   api/library_root
+   Full API <api/unabridged_api>
+   File structure <api/unabridged_orphan>
 
 Indices and Search
 ==================


### PR DESCRIPTION
This PR fixes a warning about the library API document not being included in the document, and also fixes the sidebar rendering (table of content shows up in the sidebar correctly).

These two issues are connected because the Sphinx html theme uses the `:toctree:` directive to create the sidebar.

References:
* Exhale, link to generated documentation API: https://exhale.readthedocs.io/en/latest/usage.html#make-your-documentation-link-to-the-generated-api
* Sphinx rtd theme, table of content options: https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html#table-of-contents-options

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>
