### PR TITLE
Add markdown parsing support to `rosdoc2`

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -74,6 +74,8 @@ if rosdoc2_settings.get('enable_exhale', True):
     print('[rosdoc2] enabling exhale', file=sys.stderr)
     extensions.append('exhale')
     ensure_global('exhale_args', {{}})
+    
+    from exhale import utils
     exhale_args.update({{
         # These arguments are required.
         "containmentFolder": "{user_sourcedir}/api",

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -87,9 +87,9 @@ if rosdoc2_settings.get('enable_exhale', True):
         "exhaleExecutesDoxygen": False,
         # Maps markdown files to the "md" lexer, and not the "markdown" lexer
         # Pygments registers "md" as a valid markdown lexer, and not "markdown"
-        "lexerMapping": {{r".*\.md": "md",}},
+        "lexerMapping": {{r".*\.(md|markdown)$": "md",}},
         # This mapping will work when `exhale` supports `:doxygenpage:` directives
-        # Check `svenevs/exhale#111`
+        # Check https://github.com/svenevs/exhale/issues/111
         "customSpecificationsMapping": utils.makeCustomSpecificationsMapping(
         lambda kind: [":project:", ":path:", ":content-only:"] if kind == "page" else []),
     }})
@@ -178,6 +178,7 @@ master_doc = 'index'
 source_suffix = {{
     '.rst': 'restructuredtext',
     '.md': 'markdown',
+    '.markdown': 'markdown',
 }}
 
 # -- Options for HTML output -------------------------------------------------

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -85,6 +85,13 @@ if rosdoc2_settings.get('enable_exhale', True):
         # TIP: if using the sphinx-bootstrap-theme, you need
         # "treeViewIsBootstrap": True,
         "exhaleExecutesDoxygen": False,
+        # Maps markdown files to the "md" lexer, and not the "markdown" lexer
+        # Pygments registers "md" as a valid markdown lexer, and not "markdown"
+        "lexerMapping": {{r".*\.md": "md",}},
+        # This mapping will work when `exhale` supports `:doxygenpage:` directives
+        # Check `svenevs/exhale#111`
+        "customSpecificationsMapping": utils.makeCustomSpecificationsMapping(
+        lambda kind: [":project:", ":path:", ":content-only:"] if kind == "page" else []),
     }})
 
 if rosdoc2_settings.get('override_theme', True):
@@ -101,6 +108,14 @@ if rosdoc2_settings.get('automatically_extend_intersphinx_mapping', True):
     ensure_global('intersphinx_mapping', {{
         {intersphinx_mapping_extensions}
     }})
+
+if rosdoc2_settings.get('support_markdown', True):
+    print(f"[rosdoc2] adding markdown parser", file=sys.stderr)
+    # The `myst_parser` is used specifically if there are markdown files
+    # in the sphinx project
+    # TODO(aprotyas): Migrate files under the `include` tag in the project's Doxygen
+    # configuration into the Sphinx project tree used to run the Sphinx builder in.
+    extensions.append('myst_parser')
 """
 
 default_conf_py_template = """\
@@ -160,6 +175,10 @@ exclude_patterns = []
 
 master_doc = 'index'
 
+source_suffix = {{
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}}
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -204,6 +223,9 @@ rosdoc2_settings = {{
     ## scope when run with rosdoc2, and could be conditionally used in your own
     ## Sphinx conf.py file.
     # 'automatically_extend_intersphinx_mapping': True,
+
+    ## Support markdown
+    # 'support_markdown': True,
 }}
 """
 

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -93,8 +93,8 @@ if rosdoc2_settings.get('enable_exhale', True):
         # This mapping will work when `exhale` supports `:doxygenpage:` directives
         # Check https://github.com/svenevs/exhale/issues/111
         # TODO(aprotyas): Uncomment the mapping below once the above issue is resolved.
-        #"customSpecificationsMapping": utils.makeCustomSpecificationsMapping(
-        #    lambda kind: [":project:", ":path:", ":content-only:"] if kind == "page" else []),
+        # "customSpecificationsMapping": utils.makeCustomSpecificationsMapping(
+        #     lambda kind: [":project:", ":path:", ":content-only:"] if kind == "page" else []),
     }})
 
 if rosdoc2_settings.get('override_theme', True):

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -92,8 +92,9 @@ if rosdoc2_settings.get('enable_exhale', True):
         "lexerMapping": {{r".*\.(md|markdown)$": "md",}},
         # This mapping will work when `exhale` supports `:doxygenpage:` directives
         # Check https://github.com/svenevs/exhale/issues/111
-        "customSpecificationsMapping": utils.makeCustomSpecificationsMapping(
-        lambda kind: [":project:", ":path:", ":content-only:"] if kind == "page" else []),
+        # TODO(aprotyas): Uncomment the mapping below once the above issue is resolved.
+        #"customSpecificationsMapping": utils.makeCustomSpecificationsMapping(
+        #    lambda kind: [":project:", ":path:", ":content-only:"] if kind == "page" else []),
     }})
 
 if rosdoc2_settings.get('override_theme', True):

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -74,7 +74,7 @@ if rosdoc2_settings.get('enable_exhale', True):
     print('[rosdoc2] enabling exhale', file=sys.stderr)
     extensions.append('exhale')
     ensure_global('exhale_args', {{}})
-    
+
     from exhale import utils
     exhale_args.update({{
         # These arguments are required.

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     setuptools>=40.6.0
     sphinx
     sphinx-rtd-theme
+    myst-parser
 packages = find:
 tests_require =
     flake8


### PR DESCRIPTION
This PR introduces markdown parsing support in two separate ways.

1. If there are markdown files in the `Sphinx` project where the
   `SphinxBuilder` object is run, previously those files were treated as
   restructured text files. By adding the `myst-parser` to the list of
   extensions and by registering the `.md` source suffix to correspond
   to `markdown` files, the appropriate parser will be called for any
   markdown files in the `Sphinx` project tree.
   This is the less likely situation because when a default `Sphinx`
   project tree is generated, no files from the existing package
   repository is transferred.
2. If a project's Doxygen configuration includes any markdown files,
   then `exhale` provides those files with a `file_<>.rst` and a
   `program_listing_<>.rst` page, where the latter is included as a
   codeblock in the former. This is not ideal - as exhale should be
   providing such files with `:doxygenpage:` directives [(issue raised
   here)](https://github.com/svenevs/exhale/issues/111).
   Regardless, the appropriate Pygments lexer (`md`) needs to be
   registered for markdown code blocks, which this patch addresses.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>
