### PR TITLE
Add `enable_intersphinx` option in settings dict

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -226,6 +226,9 @@ rosdoc2_settings = {{
     ## settings as needed if they are set by this configuration.
     # 'enable_exhale': True,
 
+    ## This setting, if True, will ensure intersphinx is part of the 'extensions'.
+    # 'enable_intersphinx': True,
+
     ## This setting, if True, will have the 'html_theme' overridden to provide
     ## a consistent style across all of the ROS documentation.
     # 'override_theme': True,


### PR DESCRIPTION
The default `rosdoc2_settings` dictionary in `default_conf_py_template`
does not list `enable_intersphinx` as an option, even though it is used
later in `rosdoc2_wrapping_conf_py_template` as a configurable setting.

This change should allow better visibility of that option.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>
