### PR TITLE
Pin to `breathe<=4.26.0`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords = rosdoc2
 [options]
 python_requires = >=3.5
 install_requires =
-    breathe
+    breathe<=4.26.0
     catkin_pkg
     exhale
     osrf_pycommon


### PR DESCRIPTION
As discovered in https://github.com/svenevs/exhale/issues/98,
older versions of `breathe` do not throw unresolved function
name warnings and/or choke on template parameter lists.

Hence, temporarily pinning to 4.26.0.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>
