### PR TITLE
Use :content-only: as the doxygenpage directive.

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -76,7 +76,7 @@ if rosdoc2_settings.get('enable_exhale', True):
     ensure_global('exhale_args', {{}})
 
     default_exhale_specs_mapping = {{
-        'page': [':content:'],
+        'page': [':content-only:'],
         **dict.fromkeys(
             ['class', 'struct'],
             [':members:', ':protected-members:', ':undoc-members:']),


### PR DESCRIPTION
According to the documentation, that is the syntax that is
supported.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

The breathe documentation that talks about this is here: https://github.com/michaeljones/breathe/blob/master/documentation/source/directives.rst#doxygenpage