### PR TITLE
[Test] Ignore W503 warnings in Flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = W503
+max-line-length = 100

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-ignore = W503
-max-line-length = 100

--- a/rosdoc2/verbs/build/builder.py
+++ b/rosdoc2/verbs/build/builder.py
@@ -20,9 +20,7 @@ logger = logging.getLogger('rosdoc2')
 
 
 class Builder:
-    """
-    Base class for all builders, which just takes care of some boilerplate logic.
-    """
+    """Base class for all builders, which just takes care of some boilerplate logic."""
 
     def __init__(self, builder_name, builder_entry_dictionary, build_context):
         """Construct a new Builder."""

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -26,7 +26,7 @@ LOG.setLevel(logging.ERROR)
 
 def test_flake8():
     style_guide = get_style_guide(
-        extend_ignore=['D100', 'D104'],
+        extend_ignore=['D100', 'D104', 'W503'],
         show_source=True,
     )
     style_guide_tests = get_style_guide(


### PR DESCRIPTION
Flake8 generates warnings for both W503 and W504 - line breaks before
and after binary operators respectively.
I came across both together when running CI for #28, and it's difficult
to satisfy both. Plus, it's documented that W503 is incompatible with
PEP 8. Reference: https://bugs.python.org/issue26763

As such, this PR chooses to ignore W503 warnings for this project.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>