### PR TITLE
Copy user files into docs_build so they can be referenced in conf.py

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -487,6 +487,13 @@ class SphinxBuilder(Builder):
         intersphinx_mapping_extensions,
     ):
         """Generate the rosdoc2 sphinx project configuration files."""
+        # Copy all user content, like images or documentation files, to the wrapping directory
+        if user_sourcedir:
+            shutil.copytree(
+                os.path.abspath(user_sourcedir),
+                os.path.abspath(directory),
+                dirs_exist_ok=True)
+
         os.makedirs(directory, exist_ok=True)
 
         package = self.build_context.package


### PR DESCRIPTION
In support of https://github.com/locusrobotics/fuse/pull/278

`rosdoc2` `sphinx_builder` copies and wraps a user's `conf.py` in a separate `docs_build` directory outside the source tree. Unfortunately this breaks relative paths to things like images and `.rst` files. I don't see a way to get the correct absolute path because `exec(open("...").read())` is used by the wrapping `conf.py` to load the user's `conf.py`.

This PR solves it by copying the `user_sourcedir` content into the build directory.

An alternative solution might be to make the wrapping `conf.py` `import` the user's `conf.py` so that the user could make an absolute path from `__file__`.

@methylDragon FYI