### PR TITLE
Feature: Override build_type via rosdoc2 yaml

### DIFF
--- a/rosdoc2/verbs/build/impl.py
+++ b/rosdoc2/verbs/build/impl.py
@@ -193,7 +193,7 @@ def main_impl(options):
             destination = \
                 os.path.abspath(os.path.join(package_output_directory, item))
             if os.path.isdir(destination):
-                # shutil.move behaves in a way such that if the destintation exists
+                # shutil.move behaves in a way such that if the destination exists
                 # and is a directory, it would copy the source directory into it,
                 # rather than replacing its contents or appending to it.
                 # So deleting it first will prevent that.

--- a/rosdoc2/verbs/build/inspect_package_for_settings.py
+++ b/rosdoc2/verbs/build/inspect_package_for_settings.py
@@ -61,6 +61,11 @@ settings:
     ## type. This is most useful if the user would like to generate Python API
     ## documentation for a package that is not of the `ament_python` build type.
     always_run_sphinx_apidoc: false
+
+    # This setting, if provided, will override the build_type of this package
+    # for documentation purposes only. If not provided, documentation will be
+    # generated assuming the build_type in package.xml.
+    # override_build_type: 'ament_python'
 builders:
     ## Each stanza represents a separate build step, performed by a specific 'builder'.
     ## The key of each stanza is the builder to use; this must be one of the

--- a/rosdoc2/verbs/build/parse_rosdoc2_yaml.py
+++ b/rosdoc2/verbs/build/parse_rosdoc2_yaml.py
@@ -60,6 +60,7 @@ def parse_rosdoc2_yaml(yaml_string, build_context):
     build_context.python_source = settings_dict.get('python_source', None)
     build_context.always_run_doxygen = settings_dict.get('always_run_doxygen', False)
     build_context.always_run_sphinx_apidoc = settings_dict.get('always_run_sphinx_apidoc', False)
+    build_context.build_type =settings_dict.get('override_build_type', build_context.build_type)
 
     if 'builders' not in config:
         raise ValueError(

--- a/rosdoc2/verbs/build/parse_rosdoc2_yaml.py
+++ b/rosdoc2/verbs/build/parse_rosdoc2_yaml.py
@@ -60,7 +60,7 @@ def parse_rosdoc2_yaml(yaml_string, build_context):
     build_context.python_source = settings_dict.get('python_source', None)
     build_context.always_run_doxygen = settings_dict.get('always_run_doxygen', False)
     build_context.always_run_sphinx_apidoc = settings_dict.get('always_run_sphinx_apidoc', False)
-    build_context.build_type =settings_dict.get('override_build_type', build_context.build_type)
+    build_context.build_type = settings_dict.get('override_build_type', build_context.build_type)
 
     if 'builders' not in config:
         raise ValueError(


### PR DESCRIPTION
This PR allows users to pass an `override_build_type` parameter via the rosdoc2.yaml settings.

I've found this to be the easiest way to get document generation for `rclpy` like packages to work. ie, where the `build_type` in `package.xml` is `ament_cmake` but we want autodoc generation of the python modules within `rclpy/rclpy`.