### PR TITLE
Add pytest markers, junit suite name

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,12 +46,15 @@ zip_safe = false
 #     test
 #     test.*
 
-# [tool:pytest]
+[tool:pytest]
 # filterwarnings =
 #     error
 #     ignore:the imp module is deprecated in favour of importlib.*:DeprecationWarning
 #     ignore:the imp module is deprecated in favour of importlib.*:PendingDeprecationWarning
-# junit_suite_name = rosdoc2
+junit_suite_name = rosdoc2
+markers =
+    flake8
+    linter
 
 [options.entry_points]
 rosdoc2.verbs =

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -16,15 +16,17 @@ import logging
 import os
 import sys
 
-from flake8 import LOG
-from flake8.api.legacy import get_style_guide
+import pytest
 
 
-# suppress warning messages from flake8
-LOG.setLevel(logging.ERROR)
-
-
+@pytest.mark.flake8
+@pytest.mark.linter
 def test_flake8():
+    from flake8.api.legacy import get_style_guide
+
+    # avoid debug / info / warning messages from flake8 internals
+    logging.getLogger('flake8').setLevel(logging.ERROR)
+
     style_guide = get_style_guide(
         extend_ignore=['D100', 'D104', 'W503'],
         show_source=True,


### PR DESCRIPTION
With these markers present, pytest can be used to filter for or against "linter" or "flake8", as is possible in other ROS packages.

Additionally, by moving the imports for flake8 into the test body, tests can be executed without flake8 installed (as is a common practice in system packaging).