### PR TITLE
Use ros docker images in github runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-    - main
   pull_request:
     branches:
     - main
@@ -11,27 +9,19 @@ on:
 jobs:
   unit_tests:
     name: Unit Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        containers: ['ros-iron', 'ros-rolling']
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
-        architecture: x64
-
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.cfg') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        cache: 'pip'
 
     - name: Install pip dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+    - main
   pull_request:
     branches:
     - main
@@ -12,21 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        containers: ['ros-iron', 'ros-rolling']
+        container: ['ros:iron', 'ros:rolling']
+    container: ${{ matrix.container }}
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup python
-      uses: actions/setup-python@v5
-      with:
-        cache: 'pip'
+    - name: Install pip
+      run: apt update && apt install -y python3-pip
 
     - name: Install pip dependencies
       run: |
-       python -m pip install --upgrade --upgrade-strategy eager .[test]
-       python -m pip freeze
+       python3 -m pip install --upgrade --upgrade-strategy eager .[test]
+       python3 -m pip freeze
 
     - name: Run tests
       run: py.test --verbose test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ on:
 jobs:
   unit_tests:
     name: Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     - name: Checkout


### PR DESCRIPTION
It's a fairly trivial point, but people running ros2 (and rosdoc2) are more likely to be on ubuntu-22.04 rather than ubuntu-20.04, so update the action runner to support this. Also add python3.10 since that is now the default version. 