### PR TITLE
Allow running as module

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ rosdoc2 open ./doc_output/index.html
 
 For more advanced usage see the documentation.
 
+It may be helpful during rosdoc2 development to run a version of rosdoc2 without installing it. This can be done
+(after doing an initial normal install to make sure prerequisites are available) by running, from the rosdoc2 main directory:
+```bash
+python3 -m rosdoc2.main <options>
+```
+
 ### Set up a ROS 2 package to be used with this tool
 
 In many cases, C/C++ packages require no configuration, and will work if you simply layout your package in a standard configuration and the tool will do the rest.

--- a/rosdoc2/main.py
+++ b/rosdoc2/main.py
@@ -86,3 +86,6 @@ def main(sysargs=None):
     # Finally call the subparser's main function with the processed args
     # and the extras which the preprocessor may have returned
     sys.exit(args.main(args) or 0)
+
+if __name__ == '__main__':
+    main()

--- a/rosdoc2/main.py
+++ b/rosdoc2/main.py
@@ -87,5 +87,6 @@ def main(sysargs=None):
     # and the extras which the preprocessor may have returned
     sys.exit(args.main(args) or 0)
 
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
When developing rosdoc2, it can be convenient to run it as a module directly rather than having to install each time, or trying to make an editable install work. This minor change should allow it.