### PR TITLE
Allow ament-cmake-python build types

### DIFF
--- a/rosdoc2/verbs/build/build_context.py
+++ b/rosdoc2/verbs/build/build_context.py
@@ -30,3 +30,4 @@ class BuildContext:
         self.python_source = None
         self.always_run_doxygen = False
         self.always_run_sphinx_apidoc = False
+        self.ament_cmake_python = False

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -40,8 +40,8 @@ def generate_package_toc_entry(*, build_context) -> str:
     ament_cmake_python = build_context.ament_cmake_python
     # The TOC entries have to be indented by three (or any N) spaces
     # inside the string to fall under the `:toctree:` directive
-    toc_entry_cpp = f'   C++ API <generated/index>\n'
-    toc_entry_py = f'   Python API <modules>\n'
+    toc_entry_cpp = '   EXHALE REPLACES THIS <generated/index>\n'
+    toc_entry_py = '   Python API <modules>\n'
     toc_entry = '\n'
 
     if build_type == 'ament_python' or always_run_sphinx_apidoc or ament_cmake_python:
@@ -158,7 +158,7 @@ if rosdoc2_settings.get('enable_exhale', is_doxygen_invoked):
         "createTreeView": True,
         "fullToctreeMaxDepth": 1,
         "unabridgedOrphanKinds": [],
-        "fullApiSubSectionTitle": "Reference",
+        "fullApiSubSectionTitle": "Reference C++ API",
         # TIP: if using the sphinx-bootstrap-theme, you need
         # "treeViewIsBootstrap": True,
         "exhaleExecutesDoxygen": False,
@@ -472,13 +472,11 @@ class SphinxBuilder(Builder):
             package_src_directory,
             intersphinx_mapping_extensions)
 
-        # If the package has build type `ament_python`, or if the user configured
-        # to run `sphinx-apidoc`, then invoke `sphinx-apidoc` before building
-        if (
-            self.build_context.build_type == 'ament_python'
-            or self.build_context.always_run_sphinx_apidoc
-        ):
-
+        # If the package has python code, then invoke `sphinx-apidoc` before building
+        has_python = self.build_context.build_type == 'ament_python' or \
+            self.build_context.always_run_sphinx_apidoc or \
+            self.build_context.ament_cmake_python
+        if has_python:
             if not package_src_directory or not os.path.isdir(package_src_directory):
                 raise RuntimeError(
                     'Could not locate source directory to invoke sphinx-apidoc in. '

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -40,7 +40,7 @@ def generate_package_toc_entry(*, build_context) -> str:
     ament_cmake_python = build_context.ament_cmake_python
     # The TOC entries have to be indented by three (or any N) spaces
     # inside the string to fall under the `:toctree:` directive
-    toc_entry_cpp = '   EXHALE REPLACES THIS <generated/index>\n'
+    toc_entry_cpp = '   C++ API <generated/index>\n'
     toc_entry_py = '   Python API <modules>\n'
     toc_entry = '\n'
 
@@ -153,12 +153,13 @@ if rosdoc2_settings.get('enable_exhale', is_doxygen_invoked):
         # These arguments are required.
         "containmentFolder": "{user_sourcedir}/generated",
         "rootFileName": "index.rst",
+        "rootFileTitle": "C++ API",
         "doxygenStripFromPath": "..",
         # Suggested optional arguments.
         "createTreeView": True,
         "fullToctreeMaxDepth": 1,
         "unabridgedOrphanKinds": [],
-        "fullApiSubSectionTitle": "Reference C++ API",
+        "fullApiSubSectionTitle": "Full C++ API",
         # TIP: if using the sphinx-bootstrap-theme, you need
         # "treeViewIsBootstrap": True,
         "exhaleExecutesDoxygen": False,

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -37,13 +37,14 @@ def generate_package_toc_entry(*, build_context) -> str:
     build_type = build_context.build_type
     always_run_doxygen = build_context.always_run_doxygen
     always_run_sphinx_apidoc = build_context.always_run_sphinx_apidoc
+    ament_cmake_python = build_context.ament_cmake_python
     # The TOC entries have to be indented by three (or any N) spaces
     # inside the string to fall under the `:toctree:` directive
-    toc_entry_cpp = f'{build_context.package.name} <generated/index>\n'
-    toc_entry_py = f'{build_context.package.name} <modules>\n'
-    toc_entry = ''
+    toc_entry_cpp = f'   C++ API <generated/index>\n'
+    toc_entry_py = f'   Python API <modules>\n'
+    toc_entry = '\n'
 
-    if build_type == 'ament_python' or always_run_sphinx_apidoc:
+    if build_type == 'ament_python' or always_run_sphinx_apidoc or ament_cmake_python:
         toc_entry += toc_entry_py
     if build_type in ['ament_cmake', 'cmake'] or always_run_doxygen:
         toc_entry += toc_entry_cpp
@@ -328,8 +329,7 @@ index_rst_template = """\
 
 .. toctree::
    :maxdepth: 2
-
-   {package_toc_entry}
+{package_toc_entry}
 
 Indices and Search
 ==================

--- a/rosdoc2/verbs/build/inspect_package_for_settings.py
+++ b/rosdoc2/verbs/build/inspect_package_for_settings.py
@@ -134,4 +134,10 @@ def inspect_package_for_settings(package, tool_options):
         package_object=package,
         tool_options=tool_options,
     )
+
+    # Is this python under ament_cmake?
+    for depends in package['buildtool_depends']:
+        if str(depends) == 'ament_cmake_python':
+            build_context.ament_cmake_python = True
+
     return parse_rosdoc2_yaml(rosdoc_config_file, build_context)

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -193,6 +193,8 @@ def test_full_package(session_dir):
 
     includes = [
         PKG_NAME,
+        'python api',
+        'c++ api',
     ]
     file_includes = [
         'generated/index.html'

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -197,9 +197,14 @@ def test_full_package(session_dir):
     file_includes = [
         'generated/index.html'
     ]
+    links_exist = [
+        'full_package.dummy.html',
+        'modules.html',
+    ]
     do_test_package(PKG_NAME, session_dir,
                     includes=includes,
-                    file_includes=file_includes)
+                    file_includes=file_includes,
+                    links_exist=links_exist)
 
 
 def test_only_python(session_dir):


### PR DESCRIPTION
This enables displaying python API in a mixed module with C++.

You can see the effects in the full_package test case. That is, run the tests. Locate the test directory (which is typically at /tmp/pytest-of-<username>), serve http from there (I use ```python -m http.server 8001```), connect to localhost:8001 in your browser, and navigate to the latest full_package directory.

The index on the left should contain (and tests confirm) two items, "Python API" and "C++ API". Previously "C++ API" was expanded in the index to include the subitems "Class Hierarchy", "File Hierarchy", and "Reference". That only makes sense if the rosdoc2 output only contains the C++ API. It is intentional that those are now collapsed under a single heading "C++ API" We are adding other items there, now "Python API" and soon messages, standard documents, user documentation, and more, so we need to be clearer about what the items in the index are.
