### PR TITLE
Support msgs, services, and actions

### DIFF
--- a/rosdoc2/verbs/build/build_context.py
+++ b/rosdoc2/verbs/build/build_context.py
@@ -30,3 +30,4 @@ class BuildContext:
         self.python_source = None
         self.always_run_doxygen = False
         self.always_run_sphinx_apidoc = False
+        self.ament_cmake_python = False

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -40,8 +40,8 @@ def generate_package_toc_entry(*, build_context) -> str:
     ament_cmake_python = build_context.ament_cmake_python
     # The TOC entries have to be indented by three (or any N) spaces
     # inside the string to fall under the `:toctree:` directive
-    toc_entry_cpp = f'   C++ API <generated/index>\n'
-    toc_entry_py = f'   Python API <modules>\n'
+    toc_entry_cpp = '   EXHALE REPLACES THIS <generated/index>\n'
+    toc_entry_py = '   Python API <modules>\n'
     toc_entry = '\n'
 
     if build_type == 'ament_python' or always_run_sphinx_apidoc or ament_cmake_python:
@@ -158,7 +158,7 @@ if rosdoc2_settings.get('enable_exhale', is_doxygen_invoked):
         "createTreeView": True,
         "fullToctreeMaxDepth": 1,
         "unabridgedOrphanKinds": [],
-        "fullApiSubSectionTitle": "Reference",
+        "fullApiSubSectionTitle": "Reference C++ API",
         # TIP: if using the sphinx-bootstrap-theme, you need
         # "treeViewIsBootstrap": True,
         "exhaleExecutesDoxygen": False,
@@ -472,13 +472,11 @@ class SphinxBuilder(Builder):
             package_src_directory,
             intersphinx_mapping_extensions)
 
-        # If the package has build type `ament_python`, or if the user configured
-        # to run `sphinx-apidoc`, then invoke `sphinx-apidoc` before building
-        if (
-            self.build_context.build_type == 'ament_python'
-            or self.build_context.always_run_sphinx_apidoc
-        ):
-
+        # If the package has python code, then invoke `sphinx-apidoc` before building
+        has_python = self.build_context.build_type == 'ament_python' or \
+            self.build_context.always_run_sphinx_apidoc or \
+            self.build_context.ament_cmake_python
+        if has_python:
             if not package_src_directory or not os.path.isdir(package_src_directory):
                 raise RuntimeError(
                     'Could not locate source directory to invoke sphinx-apidoc in. '

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -43,6 +43,10 @@ def generate_package_toc_entry(*, build_context, interface_counts) -> str:
     # inside the string to fall under the `:toctree:` directive
     toc_entry_cpp = '   C++ API <generated/index>\n'
     toc_entry_py = '   Python API <modules>\n'
+    toc_entry_msg = '   Message Definitions <generated/message_definitions>\n'
+    toc_entry_srv = '   Service Definitions <generated/service_definitions>\n'
+    toc_entry_action = '   Action Definitions <generated/action_definitions>\n'
+
     toc_entry = '\n'
 
     if build_type == 'ament_python' or always_run_sphinx_apidoc or ament_cmake_python:
@@ -53,6 +57,8 @@ def generate_package_toc_entry(*, build_context, interface_counts) -> str:
         toc_entry += toc_entry_msg
     if interface_counts['srv'] > 0:
         toc_entry += toc_entry_srv
+    if interface_counts['action'] > 0:
+        toc_entry += toc_entry_action
     return toc_entry
 
 

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -40,7 +40,7 @@ def generate_package_toc_entry(*, build_context) -> str:
     ament_cmake_python = build_context.ament_cmake_python
     # The TOC entries have to be indented by three (or any N) spaces
     # inside the string to fall under the `:toctree:` directive
-    toc_entry_cpp = '   EXHALE REPLACES THIS <generated/index>\n'
+    toc_entry_cpp = '   C++ API <generated/index>\n'
     toc_entry_py = '   Python API <modules>\n'
     toc_entry = '\n'
 
@@ -153,12 +153,13 @@ if rosdoc2_settings.get('enable_exhale', is_doxygen_invoked):
         # These arguments are required.
         "containmentFolder": "{user_sourcedir}/generated",
         "rootFileName": "index.rst",
+        "rootFileTitle": "C++ API",
         "doxygenStripFromPath": "..",
         # Suggested optional arguments.
         "createTreeView": True,
         "fullToctreeMaxDepth": 1,
         "unabridgedOrphanKinds": [],
-        "fullApiSubSectionTitle": "Reference C++ API",
+        "fullApiSubSectionTitle": "Full C++ API",
         # TIP: if using the sphinx-bootstrap-theme, you need
         # "treeViewIsBootstrap": True,
         "exhaleExecutesDoxygen": False,

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -37,13 +37,14 @@ def generate_package_toc_entry(*, build_context) -> str:
     build_type = build_context.build_type
     always_run_doxygen = build_context.always_run_doxygen
     always_run_sphinx_apidoc = build_context.always_run_sphinx_apidoc
+    ament_cmake_python = build_context.ament_cmake_python
     # The TOC entries have to be indented by three (or any N) spaces
     # inside the string to fall under the `:toctree:` directive
-    toc_entry_cpp = f'{build_context.package.name} <generated/index>\n'
-    toc_entry_py = f'{build_context.package.name} <modules>\n'
-    toc_entry = ''
+    toc_entry_cpp = f'   C++ API <generated/index>\n'
+    toc_entry_py = f'   Python API <modules>\n'
+    toc_entry = '\n'
 
-    if build_type == 'ament_python' or always_run_sphinx_apidoc:
+    if build_type == 'ament_python' or always_run_sphinx_apidoc or ament_cmake_python:
         toc_entry += toc_entry_py
     if build_type in ['ament_cmake', 'cmake'] or always_run_doxygen:
         toc_entry += toc_entry_cpp
@@ -328,8 +329,7 @@ index_rst_template = """\
 
 .. toctree::
    :maxdepth: 2
-
-   {package_toc_entry}
+{package_toc_entry}
 
 Indices and Search
 ==================

--- a/rosdoc2/verbs/build/generate_interface_docs.py
+++ b/rosdoc2/verbs/build/generate_interface_docs.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 
 
-"""Generate rst files for messages and services."""
+"""Generate rst files for messages, services, and actions."""
 
 import fnmatch
 import os
-
-# from jinja2 import Template
 
 iface_fm_rst = """\
 {iface_name}
@@ -64,7 +62,7 @@ def generate_interface_docs(path: str, package: str, output_dir: str):
     :rtype: dict(str, int)
     """
     counts = {}
-    for type_info in (('msg', 'message'), ('srv', 'service')):
+    for type_info in (('msg', 'message'), ('srv', 'service'), ('action', 'action')):
         count = 0
         (type_ext, type_name) = type_info
         interfaces = _find_files_with_extension(path, type_ext)

--- a/rosdoc2/verbs/build/generate_interface_docs.py
+++ b/rosdoc2/verbs/build/generate_interface_docs.py
@@ -1,0 +1,102 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Generate rst files for messages and services."""
+
+import fnmatch
+import os
+
+# from jinja2 import Template
+
+iface_fm_rst = """\
+{iface_name}
+{name_underline}
+This is a ROS {type_name} definition.
+
+**Source**
+
+.. literalinclude:: {relative_path}
+
+"""
+
+toc_fm_rst = """\
+{title}
+{title_underline}
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   {type_ext}/*
+
+"""
+
+
+def _find_files_with_extension(path, ext):
+    # Partly adapted from https://github.com/ros-infrastructure/rosdoc_lite
+    matches = []
+    for root, _, filenames in os.walk(path):
+        for filename in fnmatch.filter(filenames, f'*.{ext}'):
+            matches.append((os.path.splitext(filename)[0], os.path.join(root, filename)))
+    return matches
+
+
+def generate_interface_docs(path: str, package: str, output_dir: str):
+    """
+    Generate rst files from messages and services.
+
+    :param str path: Directory path to start search for files
+    :param str package: Name of containing package
+    :param str output_dir: Directory path to write output
+    :return: {'msg':msg_count, 'srv':srv_count} count of files written
+    :rtype: dict(str, int)
+    """
+    counts = {}
+    for type_info in (('msg', 'message'), ('srv', 'service')):
+        count = 0
+        (type_ext, type_name) = type_info
+        interfaces = _find_files_with_extension(path, type_ext)
+        output_dir_ex = os.path.join(output_dir, type_ext)
+        title = type_name.capitalize() + ' Definitions'
+        for interface in interfaces:
+            (iface_name, iface_path) = interface
+            relative_path = os.path.relpath(iface_path, start=output_dir_ex)
+            template_vars = {
+                'iface_name': iface_name,
+                'name_underline': '=' * len(iface_name),
+                'type_name': type_name,
+                'package': package,
+                'type_ext': type_ext,
+                'relative_path': relative_path,
+                'title': title,
+                'title_underline': '=' * len(title)
+            }
+            iface_rst = iface_fm_rst.format_map(template_vars)
+
+            if not os.path.exists(output_dir_ex):
+                os.makedirs(output_dir_ex)
+            output_path = os.path.join(output_dir_ex, f'{iface_name}.rst')
+            with open(output_path, 'w') as f:
+                f.write(iface_rst)
+            count += 1
+        if count > 0:
+            # generate a toc entry rst file for this type
+            toc_rst = toc_fm_rst.format_map(template_vars)
+            toc_name = type_name + '_definitions.rst'
+            toc_path = os.path.join(output_dir, toc_name)
+            with open(toc_path, 'w') as f:
+                f.write(toc_rst)
+        counts[type_ext] = count
+    return counts

--- a/rosdoc2/verbs/build/inspect_package_for_settings.py
+++ b/rosdoc2/verbs/build/inspect_package_for_settings.py
@@ -134,4 +134,10 @@ def inspect_package_for_settings(package, tool_options):
         package_object=package,
         tool_options=tool_options,
     )
+
+    # Is this python under ament_cmake?
+    for depends in package['buildtool_depends']:
+        if str(depends) == 'ament_cmake_python':
+            build_context.ament_cmake_python = True
+
     return parse_rosdoc2_yaml(rosdoc_config_file, build_context)

--- a/test/packages/full_package/action/Fibonacci.action
+++ b/test/packages/full_package/action/Fibonacci.action
@@ -1,0 +1,11 @@
+# This action is based on the action tutorial
+# https://docs.ros.org/en/rolling/Tutorials/Intermediate/Creating-an-Action.html
+
+# order of the Fibonacci sequence we want to compute
+int32 order
+---
+# the final result
+int32[] sequence
+---
+# feedback of what is completed so far
+int32[] partial_sequence

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -195,6 +195,9 @@ def test_full_package(session_dir):
         PKG_NAME,
         'python api',
         'c++ api',
+        'message definitions',
+        'service definitions',
+        'action definitions'
     ]
     file_includes = [
         'generated/index.html'

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -193,6 +193,8 @@ def test_full_package(session_dir):
 
     includes = [
         PKG_NAME,
+        'python api',
+        'c++ api',
     ]
     file_includes = [
         'generated/index.html'

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -197,9 +197,14 @@ def test_full_package(session_dir):
     file_includes = [
         'generated/index.html'
     ]
+    links_exist = [
+        'full_package.dummy.html',
+        'modules.html',
+    ]
     do_test_package(PKG_NAME, session_dir,
                     includes=includes,
-                    file_includes=file_includes)
+                    file_includes=file_includes,
+                    links_exist=links_exist)
 
 
 def test_only_python(session_dir):


### PR DESCRIPTION
This will show messages, services, and actions (with just their raw text) in packages that already have C++ content. Unfortunately it does not resolve issue #54, that will take additional effort.

In the test cases, full_package has messages, services, and actions that can show how this works.

The majority of real packages that have msg definitions seem to be in msg-only packages, which will still fail. So this PR does not really solve the real-world problem yet, but I will submit a PR to address msg-only packages. It does not really matter to me if this is reviewed and landed first, or if you wait until I resolve the case of message-only packages, it is the same amount of work for me. Your choice.

