### PR TITLE
Restrict interfaces by directory (fixes #82)

### DIFF
--- a/rosdoc2/verbs/build/generate_interface_docs.py
+++ b/rosdoc2/verbs/build/generate_interface_docs.py
@@ -44,8 +44,12 @@ toc_fm_rst = """\
 
 def _find_files_with_extension(path, ext):
     # Partly adapted from https://github.com/ros-infrastructure/rosdoc_lite
+    # and https://stackoverflow.com/questions/19859840/excluding-directories-in-os-walk
     matches = []
-    for root, _, filenames in os.walk(path):
+    excludes = ['test', 'doc']
+    for root, dirs, filenames in os.walk(path, topdown=True):
+        # exclude directories
+        dirs[:] = [d for d in dirs if d not in excludes]
         for filename in fnmatch.filter(filenames, f'*.{ext}'):
             matches.append((os.path.splitext(filename)[0], os.path.join(root, filename)))
     return matches

--- a/test/packages/full_package/test/msg/DontShowMe.msg
+++ b/test/packages/full_package/test/msg/DontShowMe.msg
@@ -1,0 +1,2 @@
+# Dummy message that should not be documented
+float64 the_variable

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -206,9 +206,13 @@ def test_full_package(session_dir):
         'full_package.dummy.html',
         'modules.html',
     ]
+    excludes = [
+        'dontshowme'
+    ]
     do_test_package(PKG_NAME, session_dir,
                     includes=includes,
                     file_includes=file_includes,
+                    excludes=excludes,
                     links_exist=links_exist)
 
 


### PR DESCRIPTION
I'm willing to restrict the search to certain directories, but it would be good if there was a reference that supports that. Otherwise this seems to work.