### PR TITLE
Limit navigation_depth to 4, fixes #56

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -278,7 +278,7 @@ html_theme_options = {{
     # Toc options
     'collapse_navigation': False,
     'sticky_navigation': True,
-    'navigation_depth': -1,
+    'navigation_depth': 4,
     'includehidden': True,
     'titles_only': False,
 }}


### PR DESCRIPTION
Fixes #56 

The html_theme_option 'navigation_depth' has a large impact on the size of the generated output. This patch changes that from infinite (-1) to 4.

Size effects for rmf_utils iron:
depth = 2: 60M
depth = 3: 61M
depth = 4: 112M
depth = -1: 332M

With depth = 4, the C++ API section in the toc shows like:
C++ API
--Full C++ API
----Classes and Structs
------Class LazyExpression

That is, the toc shows the class name, but not any details of the class. You need to click on the name to reach the class page to get that.

I think that is the right amount of detail, plus it is reducing the total file space to 1/3 of the current value.