### PR TITLE
Fix flow-map syntax of rosdoc2.yaml

### DIFF
--- a/rosdoc2/verbs/build/inspect_package_for_settings.py
+++ b/rosdoc2/verbs/build/inspect_package_for_settings.py
@@ -80,13 +80,13 @@ builders:
     - doxygen: {{
         name: '{package_name} Public C/C++ API',
         output_dir: 'generated/doxygen'
-    }}
+      }}
     - sphinx: {{
         name: '{package_name}',
         ## This path is relative to output staging.
         doxygen_xml_directory: 'generated/doxygen/xml',
         output_dir: ''
-    }}
+      }}
 """
 
 


### PR DESCRIPTION
There are some issues with the yaml syntax of the default config.

I created a default rosdoc2.yaml with `rosdoc2 default_config --package-path src/realtime_tools/`, but the linter complains

```
Flow map in block collection must be sufficiently indented and end with a }YAML
Unexpected flow-map-end token in YAML stream: "}"YAML
```

Increasing the indent fixes this for me.