### PR TITLE
Use venv for tests, pipx for install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   unit_tests:
     name: Unit Tests
+    defaults:
+      run:
+        shell: bash
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -17,18 +20,29 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Install pip
-      run: apt update && apt install -y python3-pip
-
-    - name: Install pip dependencies
-      run: |
-       python3 -m pip install --upgrade --upgrade-strategy eager .[test]
-       python3 -m pip freeze
+      uses: actions/checkout@v4
 
     - name: Install apt dependencies
-      run: sudo apt update && sudo apt install -y doxygen graphviz
+      run: |
+       sudo apt update
+       sudo apt install -y doxygen graphviz python3-pip python3-venv python3-pytest pipx python3-sphinx
 
-    - name: Run tests
-      run: py.test --verbose test
+    - name: Smoke test of pipx install
+      run: |
+       PATH="$HOME/.local/bin:$PATH"
+       pipx install .
+       rosdoc2 build -d tmp/docs_build -c /tmp/cross_references -o /tmp/docs_output -p test/packages/full_package
+       if [ ! -f /tmp/docs_output/full_package/index.html ]; then
+         echo "Failed to find any output from rosdoc2"
+         exit 2
+       else
+        echo "rosdoc2 ran successfully under pipx"
+       fi
+
+    - name: Install modules and run tests in venv
+      run: |
+       python3 -m venv env
+       source env/bin/activate
+       python3 -m pip install --upgrade --upgrade-strategy eager .[test]
+       python3 -m pip freeze
+       py.test --verbose test

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -19,13 +19,13 @@ import shutil
 import subprocess
 
 import setuptools
+from sphinx.cmd.build import main as sphinx_main
 
 from ..builder import Builder
 from ..collect_inventory_files import collect_inventory_files
 from ..create_format_map_from_package import create_format_map_from_package
 from ..generate_interface_docs import generate_interface_docs
 from ..include_user_docs import include_user_docs
-
 logger = logging.getLogger('rosdoc2')
 
 
@@ -550,17 +550,12 @@ class SphinxBuilder(Builder):
         # Invoke Sphinx-build.
         sphinx_output_dir = os.path.abspath(
             os.path.join(wrapped_sphinx_directory, 'sphinx_output'))
-        cmd = [
-            'sphinx-build',
-            wrapped_sphinx_directory,
-            sphinx_output_dir,
-        ]
         logger.info(
-            f"Running Sphinx-build: '{' '.join(cmd)}' in '{wrapped_sphinx_directory}'"
+            f"Running sphinx_build with: [{wrapped_sphinx_directory}, '{sphinx_output_dir}]'"
         )
-        completed_process = subprocess.run(cmd, cwd=wrapped_sphinx_directory)
-        msg = f"Sphinx-build exited with return code '{completed_process.returncode}'"
-        if completed_process.returncode == 0:
+        returncode = sphinx_main([wrapped_sphinx_directory, sphinx_output_dir])
+        msg = f"sphinx_build exited with return code '{returncode}'"
+        if returncode == 0:
             logger.info(msg)
         else:
             raise RuntimeError(msg)


### PR DESCRIPTION
This approach to fixing the issues in Ubuntu 24 is to use pipx for a normal installation of rosdoc2, but tests using venv.

Using pipx required some changes to sphinx_builder. The venv that is setup behind the scenes for pipx did not translate into a python subprocess, so runs of sphinx-build failed because of a missing exhale dependency. The solution to that was to follow the same process I do in tests, namely to run sphinx directly as a python module and not as a subprocess. That did not seem to be needed for sphinx-apidoc.

pipx has enough issues that it was worth adding directly to the test suite, simulating what we expect for  user install.