### PR TITLE
Rename readme_include.rst to stop name collisions

### DIFF
--- a/rosdoc2/verbs/build/builders/index.rst.jinja
+++ b/rosdoc2/verbs/build/builders/index.rst.jinja
@@ -19,7 +19,7 @@ Welcome to the documentation for {{ package.name }}
 
    Documentation <user_docs>
 {% endif %}
-{% if has_readme %}.. include:: readme_include.rst{% endif%}
+{% if has_readme %}.. include:: __readme_include.rst{% endif%}
 
 Indices and Search
 ==================

--- a/rosdoc2/verbs/build/standard_documents.py
+++ b/rosdoc2/verbs/build/standard_documents.py
@@ -108,5 +108,5 @@ def generate_standard_document_files(standard_docs, wrapped_sphinx_directory):
             else:
                 file_contents += f'.. literalinclude:: {file_path}\n'
                 file_contents += '   :language: none\n'
-            with open(os.path.join(wrapped_sphinx_directory, 'readme_include.rst'), 'w+') as f:
+            with open(os.path.join(wrapped_sphinx_directory, '__readme_include.rst'), 'w+') as f:
                 f.write(file_contents)


### PR DESCRIPTION
Fixes #102
