### PR TITLE
Add package description to home page

### DIFF
--- a/rosdoc2/verbs/build/builders/index.rst.jinja
+++ b/rosdoc2/verbs/build/builders/index.rst.jinja
@@ -3,6 +3,8 @@
 Welcome to the documentation for {{ package.name }}
 ================================={% for _ in package.name %}={% endfor %}
 
+{{ package.description }}
+
 .. toctree::
    :maxdepth: 2
 

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -212,6 +212,7 @@ def test_full_package(session_dir):
         'action definitions',
         'instructions',  # has documentation
         'changelog',
+        'full ros2 test package',  # the package description
     ]
     file_includes = [
         'generated/index.html'


### PR DESCRIPTION
Note I used package.description rather than package_description. I intend to refactor the template variables to simplify them, in anticipation of documenting them for package authors to use if modifying .jinja files. There is no need to include package attributes that are available directly from the package.