### PR TITLE
Add url links in home page

### DIFF
--- a/rosdoc2/verbs/build/builders/index.rst.jinja
+++ b/rosdoc2/verbs/build/builders/index.rst.jinja
@@ -5,6 +5,13 @@ Welcome to the documentation for {{ package.name }}
 
 {{ package.description }}
 
+{% if package.urls -%}
+* Links
+{% for link in package.urls %}
+  * `{{ link.type.capitalize() }} <{{ link.url }}>`_
+{% endfor -%}
+{% endif -%}
+
 .. toctree::
    :maxdepth: 2
 

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -156,8 +156,9 @@ def do_test_package(
             f'a link should exist containing the string <{item}>'
         link_object = urlparse(found_item)
         link_path = output_dir / name / link_object.path
-        assert link_path.is_file(), \
-            f'file represented by <{found_item}> should exist at <{link_path}>'
+        if not item.startswith('http'):
+            assert link_path.is_file(), \
+                f'file represented by <{found_item}> should exist at <{link_path}>'
 
     # look for fragments of text
     for item in fragments:
@@ -182,6 +183,7 @@ def test_minimum_package(session_dir):
     ]
     excludes = [
         'classes and structs',  # only found in C++ projects
+        'links',  # only found if urls defined
     ]
     file_includes = [
         'search.html',
@@ -215,6 +217,7 @@ def test_full_package(session_dir):
         'instructions',  # has documentation
         'changelog',
         'full ros2 test package',  # the package description
+        'links',
     ]
     file_includes = [
         'generated/index.html'
@@ -224,6 +227,7 @@ def test_full_package(session_dir):
         'modules.html',
         'user_docs/morestuff/more_of_more/subsub.html',  # a deep documentation file
         'standards.html',
+        'https://example.com/repo',
     ]
     excludes = [
         'dontshowme'


### PR DESCRIPTION
This adds the urls from the package to the home page.

Note these are not included in the index in this version. I could do that, but I think I would need to first generate an rst page containing just these links.

In any case, the home page is getting cluttered now with lots of stuff that is also accessible from the index. I plan to do a revamp of that, hiding many of the items that are in the index from the home page, and simplifying the home page. In that case these URLs would only be on the home page, and not in the index. I think that is the right decision, but it is a matter of opinion.