### PR TITLE
Title change to ROS2 Package <thepackage>

### DIFF
--- a/rosdoc2/verbs/build/builders/index.rst.jinja
+++ b/rosdoc2/verbs/build/builders/index.rst.jinja
@@ -1,7 +1,7 @@
 .. GENERATED_CONTENT by rosdoc2.verbs.build.builders.sphinx_builder.
 
-ROS2 Package <{{ package.name }}>
-=============={% for _ in package.name %}={% endfor %}=
+{{ package.name }}
+{% for _ in package.name %}={% endfor %}
 
 {{ package.description }}
 

--- a/rosdoc2/verbs/build/builders/index.rst.jinja
+++ b/rosdoc2/verbs/build/builders/index.rst.jinja
@@ -1,7 +1,7 @@
 .. GENERATED_CONTENT by rosdoc2.verbs.build.builders.sphinx_builder.
 
-Welcome to the documentation for {{ package.name }}
-================================={% for _ in package.name %}={% endfor %}
+ROS2 Package <{{ package.name }}>
+=============={% for _ in package.name %}={% endfor %}=
 
 {{ package.description }}
 


### PR DESCRIPTION
Would it be OK if we gave a slightly more descriptive title? IIUC correctly "Welcome to the documentation for ..." comes from the default package generation for sphinx. We have a little more information, like this is a ROS2 package we are showing. The title should say that. "Welcome to the documentation for ..." is pretty useless verbiage. When I come to the page, particularly if I have lots of tabs opened, it would be good to have more hints of what I am looking at.

We could mark the package title differently if you don't like the <thepackage> style. Italics would also be straightforward.