### PR TITLE
Move Index to toc, remove Search link

### DIFF
--- a/rosdoc2/verbs/build/builders/index.rst.jinja
+++ b/rosdoc2/verbs/build/builders/index.rst.jinja
@@ -30,8 +30,8 @@ Welcome to the documentation for {{ package.name }}
 {% endif %}
 {% if has_readme %}.. include:: __readme_include.rst{% endif%}
 
-Indices and Search
-==================
+.. toctree::
+   :hidden:
 
-* :ref:`genindex`
-* :ref:`search`
+   genindex
+


### PR DESCRIPTION
Fixes #117

Generally I'd like to remove items from the home page that are better accessed directly from the toc sidebar, this is one case of that. But in this case we are also adding something to the toc. Previously adding the index to the toc could only be done with a template, but from Sphinx 5.2 it is easily done.

The search link appears useless to me, search is accessed from the top of the sidebar.