### PR TITLE
Prepare to release rosdoc2 into the ROS apt repositories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 env/
 build/
 !rosdoc2/verbs/build
+deb_dist/
 develop-eggs/
 dist/
 downloads/

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [rosdoc2]
 No-Python2:
-Depends3: python3-breathe, python3-catkin-pkg-modules, python3-osrf-pycommon, python3-setuptools, python3-sphinx, python3-yaml, doxygen
-Suite: focal jammy noble bookworm trixie
+Depends3: python3-breathe, python3-catkin-pkg-modules, python3-exhale, python3-jinja2, python3-myst-parser, python3-osrf-pycommon, python3-setuptools, python3-sphinx, python3-sphinx-rtd-theme, python3-yaml, doxygen
+Suite: jammy noble bookworm trixie
 X-Python3-Version: >= 3.6

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [rosdoc2]
 No-Python2:
 Depends3: python3-breathe, python3-catkin-pkg-modules, python3-osrf-pycommon, python3-setuptools, python3-sphinx, python3-pyyaml, doxygen
-Suite: bionic focal stretch buster
+Suite: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.6

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [rosdoc2]
 No-Python2:
-Depends3: python3-breathe, python3-catkin-pkg-modules, python3-exhale, python3-jinja2, python3-myst-parser, python3-osrf-pycommon, python3-setuptools, python3-sphinx, python3-sphinx-rtd-theme, python3-yaml, doxygen
+Depends3: python3-breathe, python3-catkin-pkg-modules, python3-exhale, python3-jinja2, python3-myst-parser, python3-osrf-pycommon, python3-setuptools, python3-sphinx, python3-sphinx-rtd-theme, python3-yaml, doxygen, grapviz
 Suite: jammy noble bookworm trixie
 X-Python3-Version: >= 3.6

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [rosdoc2]
 No-Python2:
-Depends3: python3-breathe, python3-catkin-pkg-modules, python3-osrf-pycommon, python3-setuptools, python3-sphinx, python3-pyyaml, doxygen
+Depends3: python3-breathe, python3-catkin-pkg-modules, python3-osrf-pycommon, python3-setuptools, python3-sphinx, python3-yaml, doxygen
 Suite: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
In order to make rosdoc2 easier to use locally, I'm preparing to release it via the ros_bootstrap repo into ROS repositories.

While building and running test installs of the package I found a few issues.

* Drop Ubuntu Bionic
* Add Ubuntu Jammy
* Add Ubuntu Noble
* Drop Debian Stretch
* Drop Debian Buster
* Add Debian Bookworm
* Add Debian Trixie
* Drop Ubuntu Focal (exhale and myst-parser are not available on Focal)