### PR TITLE
Add long_description_content_type to support publishing on PyPI.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
 license = Apache License, Version 2.0
 description = Command line tool to build documentation for ROS packages.
 long_description = file: README.md
+long_description_content_type = text/markdown
 keywords = rosdoc2
 
 [options]


### PR DESCRIPTION
This was necessary to publish rosdoc2 on PyPI.