### PR TITLE
Fix graphviz typo in stdeb.cfg.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [rosdoc2]
 No-Python2:
-Depends3: python3-breathe, python3-catkin-pkg-modules, python3-exhale, python3-jinja2, python3-myst-parser, python3-osrf-pycommon, python3-setuptools, python3-sphinx, python3-sphinx-rtd-theme, python3-yaml, doxygen, grapviz
+Depends3: python3-breathe, python3-catkin-pkg-modules, python3-exhale, python3-jinja2, python3-myst-parser, python3-osrf-pycommon, python3-setuptools, python3-sphinx, python3-sphinx-rtd-theme, python3-yaml, doxygen, graphviz
 Suite: jammy noble bookworm trixie
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
Of course, discovered after publishing to apt and PyPI (which is unaffected by this issue).
I thought I'd done a successful dry-run but clearly that was before I snuck the last commit on #128 to include "grapviz". 🤦🏼 