### PR TITLE
Prepare 0.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+0.2.1 (2024-07-14 12:45:00 -0700)
+---------------------------------
+- Fix graphviz typo in stdeb.cfg. `#132 <https://github.com/ros-infrastructure/rosdoc2/pull/132>`_
+- Add long_description_content_type to support publishing on PyPI. `#131 <https://github.com/ros-infrastructure/rosdoc2/pull/131>`_
+
 0.2.0 (2024-07-11 16:00:00 -0700)
 ---------------------------------
 - Initial released version of rosdoc2.

--- a/rosdoc2/__init__.py
+++ b/rosdoc2/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.1'
+__version__ = '0.2.2.dev0'

--- a/rosdoc2/__init__.py
+++ b/rosdoc2/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.2.1.dev0'
+__version__ = '0.2.1'


### PR DESCRIPTION
Follow-up release to resolve the typo blocking installation of rosdoc2 0.2.0 via apt (#132) and also includes a fix for PyPI publishing (#131).

This change will be fast-forwarded onto main and the first commit will be tagged 0.2.1.