### PR TITLE
Prevent package finders from processing the wrapped directory

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -16,6 +16,7 @@ from importlib import resources
 import json
 import logging
 import os
+from pathlib import Path
 import shutil
 import subprocess
 
@@ -417,9 +418,7 @@ class SphinxBuilder(Builder):
         wrapped_sphinx_directory = os.path.abspath(
             os.path.join(doc_build_folder, 'wrapped_sphinx_directory'))
         os.makedirs(wrapped_sphinx_directory, exist_ok=True)
-        ignore_path = os.path.join(wrapped_sphinx_directory, 'COLCON_IGNORE')
-        with open(ignore_path, 'a'):
-            pass
+        Path(wrapped_sphinx_directory).joinpath('COLCON_IGNORE').touch()
 
         # Generate rst documents for interfaces
         interface_counts = generate_interface_docs(

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -417,6 +417,9 @@ class SphinxBuilder(Builder):
         wrapped_sphinx_directory = os.path.abspath(
             os.path.join(doc_build_folder, 'wrapped_sphinx_directory'))
         os.makedirs(wrapped_sphinx_directory, exist_ok=True)
+        ignore_path = os.path.join(wrapped_sphinx_directory, 'COLCON_IGNORE')
+        with open(ignore_path, 'a'):
+            pass
 
         # Generate rst documents for interfaces
         interface_counts = generate_interface_docs(


### PR DESCRIPTION
Fixes #125 

Adds a blank COLCON_IGNORE file to the wrapped directory, to prevent package finders from thinking this is a package to process, as suggested by @damien-robotsix in #125