### PR TITLE
Use null as default for sphinx_sourcedir

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -323,8 +323,9 @@ class SphinxBuilder(Builder):
     - builder (str) (required)
       - required for all builders, must be 'sphinx' to use this class
     - sphinx_sourcedir (str) (optional)
-      - directory containing the Sphinx project, i.e. the `conf.py`, the setting
-        you would pass to sphinx-build as SOURCEDIR. Defaults to `doc`.
+      - If set, the documentation in this folder replaces the default documentation generated
+      by rosdoc2. That is, the directory you would pass to sphinx-build as SOURCEDIR.
+      Defaults to empty (or null in yaml, None in python).
     """
 
     def __init__(self, builder_name, builder_entry_dictionary, build_context):
@@ -355,6 +356,8 @@ class SphinxBuilder(Builder):
             if key in ['name', 'output_dir', 'doxygen_xml_directory']:
                 continue
             if key == 'sphinx_sourcedir':
+                if not value:
+                    continue
                 sphinx_sourcedir = os.path.join(configuration_file_dir, value)
                 if not os.path.isdir(sphinx_sourcedir):
                     raise RuntimeError(

--- a/rosdoc2/verbs/build/inspect_package_for_settings.py
+++ b/rosdoc2/verbs/build/inspect_package_for_settings.py
@@ -45,9 +45,9 @@ settings: {{
     ## documentation for a package that is not of the `ament_python` build type.
     # always_run_sphinx_apidoc: false,
 
-    # This setting, if provided, will override the build_type of this package
-    # for documentation purposes only. If not provided, documentation will be
-    # generated assuming the build_type in package.xml.
+    ## This setting, if provided, will override the build_type of this package
+    ## for documentation purposes only. If not provided, documentation will be
+    ## generated assuming the build_type in package.xml.
     # override_build_type: '{package_build_type}',
 }}
 builders:
@@ -74,9 +74,12 @@ builders:
         ## This path is relative to output staging.
         # doxygen_xml_directory: 'generated/doxygen/xml',
         # output_dir: '',
-        ## Root folder for the user-supplied documentation. If not specified, either 'doc' or
-        ## 'doc/source' will be used if renderable documentation is found there.
-        # sphinx_sourcedir: 'doc',
+        ## If sphinx_sourcedir is specified and not null, then the documentation in that folder
+        ## (specified relative to the package.xml directory) will replace rosdoc2's normal output.
+        ## If sphinx_sourcedir is left unspecified, any documentation found in the doc/ or
+        ## doc/source/ folder will still be included by default, along with other relevant package
+        ## information.
+        # sphinx_sourcedir: null,
       }}
 """
 

--- a/test/packages/default_yaml/rosdoc2.yaml
+++ b/test/packages/default_yaml/rosdoc2.yaml
@@ -24,9 +24,9 @@ settings: {
     ## documentation for a package that is not of the `ament_python` build type.
     always_run_sphinx_apidoc: false,
 
-    # This setting, if provided, will override the build_type of this package
-    # for documentation purposes only. If not provided, documentation will be
-    # generated assuming the build_type in package.xml.
+    ## This setting, if provided, will override the build_type of this package
+    ## for documentation purposes only. If not provided, documentation will be
+    ## generated assuming the build_type in package.xml.
     override_build_type: 'ament_cmake',
 }
 builders:
@@ -53,7 +53,10 @@ builders:
         ## This path is relative to output staging.
         doxygen_xml_directory: 'generated/doxygen/xml',
         output_dir: '',
-        ## Root folder for the user-supplied documentation. If not specified, either 'doc' or
-        ## 'doc/source' will be used if renderable documentation is found there.
-        # sphinx_sourcedir: 'doc',
+        ## If sphinx_sourcedir is specified and not null, then the documentation in that folder
+        ## (specified relative to the package.xml directory) will replace rosdoc2's normal output.
+        ## If sphinx_sourcedir is left unspecified, any documentation found in the doc/ or
+        ## doc/source/ folder will still be included by default, along with other relevant package
+        ## information.
+        sphinx_sourcedir: null,
       }


### PR DESCRIPTION
This is a followup to #138. The original documentation was wrong, doc/ is not a reasonable default for sphinx_sourcedir, as specifying that has the side effect of replacing the standard rosdoc2 output. That 'side effect' is actually the intended main effect of sphinx_sourcedir. We will need a new variable for the common issue that user documentation is in an alternate folder (typically docs/) but we do not want to override the default rosdoc2 output. That is a followup need.

