### PR TITLE
Remove any existing package doc_build_directory

### DIFF
--- a/rosdoc2/verbs/build/impl.py
+++ b/rosdoc2/verbs/build/impl.py
@@ -138,7 +138,9 @@ def main_impl(options):
 
     # Generate the doc build directory.
     package_doc_build_directory = os.path.join(options.doc_build_directory, package.name)
-    os.makedirs(package_doc_build_directory, exist_ok=True)
+    if os.path.exists(package_doc_build_directory):
+        shutil.rmtree(package_doc_build_directory)
+    os.makedirs(package_doc_build_directory)
 
     # Generate the "output staging" directory.
     output_staging_directory = os.path.join(package_doc_build_directory, 'output_staging')


### PR DESCRIPTION
Strange things can happen if there are leftover files in the docs_build directory. I recently came across one: if there is a previous run, then index.rst will already exist, so it will not be updated with index.rst.jinja if anything changes.

I cannot think of any good reason to leave the old docs_builds for the particular package, so this PR erases it at the beginning of the build.