### PR TITLE
Removing any unsupported extensions

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -65,6 +65,42 @@ ensure_global('author', \"\"\"{package_authors}\"\"\")
 ensure_global('release', "{package.version}")
 ensure_global('version', "{package_version_short}")
 
+# Remove any unsupported extensions
+allowed_extensions = set((
+    # Shipped with sphinx
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosectionlabel',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.coverage',
+    'sphinx.ext.doctest',
+    'sphinx.ext.duration',
+    'sphinx.ext.extlinks',
+    'sphinx.ext.githubpages',
+    'sphinx.ext.graphviz',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.imgconverter',
+    'sphinx.ext.inheritance_diagram',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.linkcode',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.todo',
+    'sphinx.ext.viewcode',
+    # Sphinx-included math extensions
+    'sphinx.ext.imgmath',
+    'sphinx.ext.mathjax',
+    # Installed by us
+    'breathe',
+    'exhale',
+    'myst_parser',
+    'sphinx_rtd_theme',
+))
+for extension in extensions[:]:
+    if extension not in allowed_extensions:
+        print(f'[rosdoc2] *** Warning *** removing extension "{{extension}}", not supported')
+        extensions.remove(extension)
+if extensions:
+    print(f'[rosdoc2] user conf.py specified allowed extensions: {{extensions}}')
+
 if rosdoc2_settings.get('enable_autodoc', True):
     print('[rosdoc2] enabling autodoc', file=sys.stderr)
     extensions.append('sphinx.ext.autodoc')

--- a/test/packages/basic_cpp/doc/conf.py
+++ b/test/packages/basic_cpp/doc/conf.py
@@ -41,6 +41,29 @@ version = '0.0'
 ## See the rosdoc2_settings below for some options on avoiding that.
 extensions = [
     'sphinx_rtd_theme',
+    'i_do_not_exist',
+    # Shipped with sphinx
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosectionlabel',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.coverage',
+    'sphinx.ext.doctest',
+    'sphinx.ext.duration',
+    'sphinx.ext.extlinks',
+    'sphinx.ext.githubpages',
+    'sphinx.ext.graphviz',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.imgconverter',
+    'sphinx.ext.inheritance_diagram',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.linkcode',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.todo',
+    'sphinx.ext.viewcode',
+    # Sphinx-included math extensions
+    'sphinx.ext.imgmath',
+    'sphinx.ext.mathjax',
+
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -126,3 +149,8 @@ rosdoc2_settings = {
     ## Support markdown
     # 'support_markdown': True,
 }
+
+## This function is required by the linkcode extension.
+## See https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html
+def linkcode_resolve(domain, info):
+    return None


### PR DESCRIPTION
Several packages add unsupported extensions in their conf.py files. Then when sphinx runs, it dies and we get no output.

This adds a check in the wrapping conf.py for the extensions that will be available when rosdoc2 is run in standard environments, and deletes (with a warning) any unsupported extension.

The PR also modifies a test to add all of these (plus one unsupported) to one of the test packages, to make sure that we both succeed with all standard extensions added, and that it does not die with an unsupported extension.

I'm trying to find PRs I can add which do apply cleanly to main (this is one),  but really I need resolution of #139 to make progress.  Most of my other patches cause conflicts which, if I attempt to resolve, will cause my rkent repo to diverge from ros-infrastructure in ways that will make it increasingly hard to maintain my fork.