### PR TITLE
Show package index in links

### DIFF
--- a/rosdoc2/verbs/build/builders/index.rst.jinja
+++ b/rosdoc2/verbs/build/builders/index.rst.jinja
@@ -5,12 +5,12 @@
 
 {{ package.description }}
 
-{% if package.urls -%}
 * Links
+
+  * `Rosindex <https://index.ros.org/p/{{package.name}}>`_
 {% for link in package.urls %}
   * `{{ link.type.capitalize() }} <{{ link.url }}>`_
 {% endfor -%}
-{% endif -%}
 
 .. toctree::
    :maxdepth: 2

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -64,7 +64,6 @@ def test_minimum_package(module_dir):
     ]
     excludes = [
         'classes and structs',  # only found in C++ projects
-        'links',  # only found if urls defined
     ]
     file_includes = [
         'search.html',


### PR DESCRIPTION
When I am working with packages, I often find myself going back and forth between rosindex and rosdoc2 representations. rosindex links to rosdoc2, this adds the reverse link from rosdoc2 back to rosindex for the package. It is a simple PR that does not conflict with others.

