### PR TITLE
Remove unneeded .doctrees from sphinx output

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -612,6 +612,11 @@ class SphinxBuilder(Builder):
         with open(os.path.abspath(inventory_file_name) + '.location.json', 'w+') as f:
             f.write(json.dumps(data))
 
+        # Sometimes sphinx generates enormous .doctree files.
+        # See https://github.com/sphinx-doc/sphinx/issues/11354
+        # These do not seem to be needed for output display, so delete them.
+        shutil.rmtree(os.path.join(sphinx_output_dir, '.doctrees'), ignore_errors=True)
+
         # Return the directory into which Sphinx generated.
         return sphinx_output_dir
 


### PR DESCRIPTION
When running rosdoc2 over entire distros (using the scan option), disk usage is quite large. Investigating, the majority of that disk usage is in the .doctrees folder. AFAICT, this folder is only used during generation of the toctrees, and [is not needed for display of the documentation from the html](https://stackoverflow.com/questions/33904042/is-doctrees-folder-required-for-displaying-html-docs-with-sphinx).

This is also an issue on the standard buildfarm, though not as bad. See https://docs.ros.org/en/rolling/p/rclcpp/.doctrees/ for example.

This PR deletes the .doctrees folder after the sphinx documentation generation is complete.