### PR TITLE
Allow null user_doc_dir in rosdoc2.yaml to ignore documentation.

### DIFF
--- a/rosdoc2/verbs/build/inspect_package_for_settings.py
+++ b/rosdoc2/verbs/build/inspect_package_for_settings.py
@@ -91,6 +91,7 @@ builders:
         ## needed. Unlike sphinx_sourcedir, specifying this does not override the standard rosdoc2
         ## output, but includes this user documentation along with other items included by default
         ## by rosdoc2.
+        ## If the value is null, any found documentation in doc/ or doc/source/ is ignored.
         # user_doc_dir: 'doc'
       }}
 """

--- a/test/packages/ignore_doc/doc/noshow.md
+++ b/test/packages/ignore_doc/doc/noshow.md
@@ -1,0 +1,2 @@
+# Do not show
+rosdoc2.yaml for this packages has user_doc_dir=null so do not show this.

--- a/test/packages/ignore_doc/package.xml
+++ b/test/packages/ignore_doc/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ignore_doc</name>
+  <version>0.1.2</version>
+  <description>I have a doc directory, but do not show</description>
+  <maintainer email="someone@example.com">Some One</maintainer>
+  <license>Apache License 2.0</license>
+  <export>
+    <build_type>ament_cmake</build_type>
+    <rosdoc2>rosdoc2.yaml</rosdoc2>
+  </export>
+</package>

--- a/test/packages/ignore_doc/rosdoc2.yaml
+++ b/test/packages/ignore_doc/rosdoc2.yaml
@@ -1,0 +1,11 @@
+type: 'rosdoc2 config'
+version: 1
+---
+settings: {
+}
+builders:
+    - doxygen: {
+      }
+    - sphinx: {
+        user_doc_dir: null
+      }

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -270,3 +270,13 @@ def test_src_alt_python(module_dir):
     do_test_package(PKG_NAME, module_dir,
                     includes=includes,
                     links_exist=links_exist)
+
+
+def test_ignore_doc(module_dir):
+    """Tests of a package with doc directory, but rosdoc2.yaml says ignore."""
+    PKG_NAME = 'ignore_doc'
+    do_build_package(DATAPATH / PKG_NAME, module_dir)
+
+    excludes = ['do not show']
+
+    do_test_package(PKG_NAME, module_dir, excludes=excludes)


### PR DESCRIPTION
Some of the larger projects have their own documentation that is built independently of rosdoc2. Rather than trying to duplicate their efforts, we should just allow the projects to add their own link in the 'documentation' area of rosdoc2.

This has the downside that the user leaves the rosdoc2 site, but I still think it is the better option for these projects.

When this PR is built, it should not show any changes since this is a new unused option, but you could see it in the tests. In my full runs, there are a number of sites with this applied (using the previous PR --yaml-extend): pinocchio, fastrtps, beluga, ign_rviz, grbl_ros, fields2cover, depthai-ros. So for example see https://rosdoc2.rosdabbler.com/humble/fields2cover/ and check the Documentation link. (These all also have additional options applied to suppress the local building of Doxygen, which is not part of the current PR).