### PR TITLE
Fix link whitespace to remove warning

### DIFF
--- a/rosdoc2/verbs/build/builders/index.rst.jinja
+++ b/rosdoc2/verbs/build/builders/index.rst.jinja
@@ -8,9 +8,9 @@
 * Links
 
   * `Rosindex <https://index.ros.org/p/{{package.name}}>`_
-{% for link in package.urls %}
+{%- for link in package.urls %}
   * `{{ link.type.capitalize() }} <{{ link.url }}>`_
-{% endfor -%}
+{%- endfor %}
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Fixes a warning during rosdoc2 generation.