### PR TITLE
Add repository url if missing

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -29,6 +29,7 @@ from ..collect_inventory_files import collect_inventory_files
 from ..create_format_map_from_package import create_format_map_from_package
 from ..generate_interface_docs import generate_interface_docs
 from ..include_user_docs import include_user_docs
+from ..package_repo_url import package_repo_url
 from ..standard_documents import generate_standard_document_files, locate_standard_documents
 
 logger = logging.getLogger('rosdoc2')
@@ -560,6 +561,9 @@ class SphinxBuilder(Builder):
             or build_context.always_run_sphinx_apidoc
             or build_context.ament_cmake_python) \
             and not build_context.never_run_sphinx_apidoc
+
+        # Try to locate package repo url if missing
+        package_repo_url(self.build_context.package)
 
         self.template_variables.update({
             'has_python': has_python,

--- a/rosdoc2/verbs/build/package_repo_url.py
+++ b/rosdoc2/verbs/build/package_repo_url.py
@@ -1,0 +1,50 @@
+# Copyright 2024 R. Kent James <kent@caspia.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+
+from catkin_pkg.package import Url
+import rosdistro
+
+logger = logging.getLogger('rosdoc2')
+
+
+def package_repo_url(package):
+    """Add a package url from rosdistro if missing."""
+    for url in package.urls:
+        if url.type == 'repository':
+            return
+
+    # Only include repo url if ROS_DISTRO is known
+    distro = os.environ.get('ROS_DISTRO')
+    package_url = None
+    if not distro:
+        logger.info('Not searching for package repository url because ROS_DISTRO is not set')
+        return
+    try:
+        index = rosdistro.get_index(rosdistro.get_index_url())
+        dist_file = rosdistro.get_distribution_file(index, distro)
+        rosdistro_package = dist_file.release_packages[package.name]
+        repo_name = rosdistro_package.repository_name
+        repo = dist_file.repositories[repo_name]
+        if repo.source_repository and repo.source_repository.url:
+            package_url = repo.source_repository.url
+            logger.info(f'Adding package repository url from rosdisto: {package_url}')
+            package.urls.append(Url(package_url, 'repository'))
+    except (KeyError, RuntimeError):
+        pass
+    finally:
+        if not package_url:
+            logger.info('No package repo url found from rosdistro')

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     Jinja2
     osrf_pycommon
     pyyaml
+    rosdistro
     setuptools>=40.6.0
     sphinx
     sphinx-rtd-theme

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [rosdoc2]
 No-Python2:
-Depends3: python3-breathe, python3-catkin-pkg-modules, python3-exhale, python3-jinja2, python3-myst-parser, python3-osrf-pycommon, python3-setuptools, python3-sphinx, python3-sphinx-rtd-theme, python3-yaml, doxygen, graphviz
+Depends3: python3-breathe, python3-catkin-pkg-modules, python3-exhale, python3-jinja2, python3-myst-parser, python3-osrf-pycommon, python3-rosdistro-modules, python3-setuptools, python3-sphinx, python3-sphinx-rtd-theme, python3-yaml, doxygen, graphviz
 Suite: jammy noble bookworm trixie
 X-Python3-Version: >= 3.6

--- a/test/packages/rclcpp/package.xml
+++ b/test/packages/rclcpp/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rclcpp</name>
+  <version>0.1.2</version>
+  <description>Dummy rcpcpp to test repo lookup</description>
+  <maintainer email="someone@example.com">Some One</maintainer>
+  <license>Apache License 2.0</license>
+</package>

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -16,6 +16,7 @@
 
 import argparse
 import logging
+import os
 import pathlib
 
 import pytest
@@ -214,6 +215,8 @@ def test_only_messages(module_dir):
     """Test a package only containing messages."""
     PKG_NAME = 'only_messages'
 
+    # This tests that run succeeds even if rosdistro entry is missing.
+    os.environ['ROS_DISTRO'] = 'rolling'
     do_build_package(DATAPATH / PKG_NAME, module_dir)
 
     includes = [
@@ -310,3 +313,18 @@ def test_ignore_doc(module_dir):
     excludes = ['do not show']
 
     do_test_package(PKG_NAME, module_dir, excludes=excludes)
+
+
+def test_rclcpp(module_dir):
+    """Tests of repo url lookup from a known standard package."""
+    PKG_NAME = 'rclcpp'
+    os.environ['ROS_DISTRO'] = 'rolling'
+    do_build_package(DATAPATH / PKG_NAME, module_dir)
+
+    includes = [
+        PKG_NAME,
+    ]
+
+    links_exist = ['https://github.com/ros2/rclcpp.git']  # Found repo url from rosdistro.
+    do_test_package(PKG_NAME, module_dir,
+                    includes=includes, links_exist=links_exist)


### PR DESCRIPTION
Currently, very few package authors actually set the package repository url, which is an official link in package.xml  But in navigating documentation, it is very important to be able to move as smoothly as possible between the rosindex package entry, rosdoc2 entry, and the repo. The repo url is readily available in rosdistro, so this PR looks it up if missing, and adds it.

Note this requires that we know the currently active rosdistro, which is not something that can be discerned directly from the package source. So the PR looks for ROS_DISTRO in the environment, and uses that if found. I'm not sure if the build farm sets that or not for doc jobs, if not that will need to be done to support this.

This also adds a new level of complexity to rosdoc2, that it is now using external information downloaded from the internet instead of just the local repo information for its build. I have a certain reluctance to add that additional complexity, but I believe the link to the repo URL is really important in documentation, so I think it is worth adding this.

