### PR TITLE
Use abspath for doxyfile to stop failure

### DIFF
--- a/rosdoc2/verbs/build/builders/doxygen_builder.py
+++ b/rosdoc2/verbs/build/builders/doxygen_builder.py
@@ -246,7 +246,8 @@ class DoxygenBuilder(Builder):
             }))
 
         # Invoke Doxygen.
-        cmd = ['doxygen', os.path.relpath(extended_doxyfile_path, start=working_directory)]
+        abs_doxyfile_path = os.path.abspath(extended_doxyfile_path)
+        cmd = ['doxygen', abs_doxyfile_path]
         logger.info(
             f"Running Doxygen: '{' '.join(cmd)}' in '{working_directory}'"
         )


### PR DESCRIPTION
This simple change use an absolute path rather than a relative path to locate the Doxyfile.

Generally the absolute vs relative path decisions in rosdoc2 are all over the map, and really need a thorough review.

In the current case, a problem occurred on my local build farm, where the locations of files were set using NFS to locations, with soft links to the actual disk storage locations. The error message in Doxygen reported the actual disk location (that is, with the soft link resolved). That caused a mismatch of the '..' count in the relative link. Perhaps somewhere Doxygen is resolving soft links. Really relative paths do not make sense in calls like this to Doxygen, as we are using relative directories on files that could be on completely separate file systems.

I could live without this change as the problem is only occurring locally for me, but I really think the absolute call is the correct way to do this, hence this change in the core code.