### PR TITLE
Don't duplicate doc links if index.rst exists

### DIFF
--- a/rosdoc2/verbs/build/include_user_docs.py
+++ b/rosdoc2/verbs/build/include_user_docs.py
@@ -16,8 +16,6 @@ import logging
 import os
 import shutil
 
-from rosdoc2.slugify import slugify
-
 logger = logging.getLogger('rosdoc2')
 
 documentation_rst_template = """\
@@ -26,9 +24,10 @@ Documentation
 
 .. toctree::
    :maxdepth: 1
+   :titlesonly:
    :glob:
 
-   {sphinx_project_directory}/*
+   {rel_user_doc_directory}/*
 """
 
 subdirectory_rst_template = """\
@@ -37,24 +36,25 @@ subdirectory_rst_template = """\
 
 .. toctree::
    :caption: Documentation in this subdirectory
-   :maxdepth: 2
+   :maxdepth: 1
+   :titlesonly:
    :glob:
 
-   {sphinx_project_directory}/{name}/*
+   *
 """
 
 
-def include_user_docs(sphinx_project_directory: str,
+def include_user_docs(rel_user_doc_directory: str,
                       output_dir: str,
                       package_xml_directory: str
                       ):
     """Generate rst files for user documents."""
-    logger.info(f'include_user_docs: sphinx_project_directory <{sphinx_project_directory}> '
+    logger.info(f'include_user_docs: rel_user_doc_directory <{rel_user_doc_directory}> '
                 f'output_dir <{output_dir}>')
     user_doc_directory = os.path.join(
-        os.path.join(package_xml_directory, sphinx_project_directory))
+        os.path.join(package_xml_directory, rel_user_doc_directory))
     doc_directories = []
-    for root, _, files in os.walk(user_doc_directory):
+    for root, dirs, files in os.walk(user_doc_directory):
         for file in files:
             # ensure a valid documentation file exists, directories might only contain resources.
             (_, ext) = os.path.splitext(file)
@@ -62,6 +62,9 @@ def include_user_docs(sphinx_project_directory: str,
                 logger.debug(f'Found renderable documentation file in {root} named {file}')
                 doc_directories.append(os.path.relpath(root, user_doc_directory))
                 break
+        if 'index.rst' in files:
+            # We assume that this index will also show any desired files in subdirectories
+            dirs.clear()
 
     if not doc_directories:
         logger.debug(f'no documentation found in {user_doc_directory}')
@@ -71,29 +74,31 @@ def include_user_docs(sphinx_project_directory: str,
     # At this point we know that there are some directories that have documentation in them under
     # /doc, but we do not know which ones might also be needed for images or includes. So we copy
     # everything to the output directory.
-    logger.info(f'Copying {os.path.join(package_xml_directory, sphinx_project_directory)} to '
-                f'{os.path.join(output_dir, sphinx_project_directory)}')
+    logger.info(f'Copying {os.path.join(package_xml_directory, rel_user_doc_directory)} to '
+                f'{os.path.join(output_dir, rel_user_doc_directory)}')
     shutil.copytree(
-        os.path.join(package_xml_directory, sphinx_project_directory),
-        os.path.join(output_dir, sphinx_project_directory),
+        os.path.join(package_xml_directory, rel_user_doc_directory),
+        os.path.join(output_dir, rel_user_doc_directory),
         dirs_exist_ok=True)
 
     toc_content = documentation_rst_template.format_map(
-        {'sphinx_project_directory': sphinx_project_directory})
+        {'rel_user_doc_directory': rel_user_doc_directory})
     # generate a glob rst entry for each directory with documents
     for relpath in doc_directories:
-        # directories that will be explicitly listed in index.rst
+        # files that will be explicitly listed in index.rst
         if relpath == '.':
             continue
-        docname = 'user_docs_' + slugify(relpath)  # This is the name that sphinx uses
-        content = subdirectory_rst_template.format_map(
-            {'name': relpath,
-             'name_underline': '=' * len(relpath),
-             'sphinx_project_directory': sphinx_project_directory})
-        sub_path = os.path.join(output_dir, docname + '.rst')
-        with open(sub_path, 'w+') as f:
-            f.write(content)
-        toc_content += f'   {relpath}/ <{docname}>\n'
+        index_path = os.path.join(output_dir, rel_user_doc_directory, relpath, 'index.rst')
+        if os.path.isfile(index_path):
+            logger.info(f'Using existing index.rst in directory {relpath}')
+        else:
+            logger.info(f'No index.rst in {relpath}, creating one.')
+            content = subdirectory_rst_template.format_map(
+                {'name': relpath,
+                 'name_underline': '=' * len(relpath)})
+            with open(index_path, 'w+') as f:
+                f.write(content)
+        toc_content += f'   {rel_user_doc_directory}/{relpath}/index\n'
 
     sub_path = os.path.join(output_dir, 'user_docs.rst')
     with open(sub_path, 'w+') as f:

--- a/test/packages/index_excludes_content/doc/somedocs.rst
+++ b/test/packages/index_excludes_content/doc/somedocs.rst
@@ -1,0 +1,4 @@
+This is some documentation
+==========================
+
+blah, blah.

--- a/test/packages/index_excludes_content/doc/with_index/deeper/a_deep_doc.rst
+++ b/test/packages/index_excludes_content/doc/with_index/deeper/a_deep_doc.rst
@@ -1,0 +1,4 @@
+We Are Deep
+-----------
+
+Really deep!

--- a/test/packages/index_excludes_content/doc/with_index/i_will_not_show/noshow.rst
+++ b/test/packages/index_excludes_content/doc/with_index/i_will_not_show/noshow.rst
@@ -1,0 +1,4 @@
+Will Not Show
+=============
+
+because this directory is not included in the parent provided index.rst.

--- a/test/packages/index_excludes_content/doc/with_index/index.rst
+++ b/test/packages/index_excludes_content/doc/with_index/index.rst
@@ -1,0 +1,9 @@
+I am an index!
+================
+
+.. toctree::
+   :glob:
+
+   deeper/*
+   the_doc
+

--- a/test/packages/index_excludes_content/doc/with_index/noshow.rst
+++ b/test/packages/index_excludes_content/doc/with_index/noshow.rst
@@ -1,0 +1,4 @@
+This is some unshown documentation
+==========================
+
+Do not show this, as there is in index.rst in this folder that does not include this.

--- a/test/packages/index_excludes_content/doc/with_index/the_doc.rst
+++ b/test/packages/index_excludes_content/doc/with_index/the_doc.rst
@@ -1,0 +1,4 @@
+More documentation
+------------------
+
+This package is amazing!

--- a/test/packages/index_excludes_content/doc/without_index/another_doc.rst
+++ b/test/packages/index_excludes_content/doc/without_index/another_doc.rst
@@ -1,0 +1,7 @@
+I am not an index!
+++++++++++++++++++
+
+We Love Documentation
+=====================
+
+blah, blah.

--- a/test/packages/index_excludes_content/doc/without_index/subdir1/afile.rst
+++ b/test/packages/index_excludes_content/doc/without_index/subdir1/afile.rst
@@ -1,0 +1,8 @@
+Documentation in subdir1
+========================
+
+stuff.
+
+More stuff
+----------
+etc.

--- a/test/packages/index_excludes_content/doc/without_index/subdir2/anotherfile.rst
+++ b/test/packages/index_excludes_content/doc/without_index/subdir2/anotherfile.rst
@@ -1,0 +1,4 @@
+Documentation in subdir2
+------------------------
+
+etc.

--- a/test/packages/index_excludes_content/package.xml
+++ b/test/packages/index_excludes_content/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>index_excludes_content</name>
+  <version>0.1.2</version>
+  <description>User specified index.rst.jinja in doc/</description>
+  <maintainer email="someone@example.com">Some One</maintainer>
+  <license>Apache License 2.0</license>
+</package>

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -354,3 +354,30 @@ def test_user_jinja_sphinx_sourcedir(module_dir):
 
     do_test_package(PKG_NAME, module_dir,
                     includes=includes)
+
+
+def test_index_excludes_content(module_dir):
+    PKG_NAME = 'index_excludes_content'
+    do_build_package(DATAPATH / PKG_NAME, module_dir)
+
+    includes = [
+        PKG_NAME,
+        'more documentation',  # file included in folder's index.rst
+    ]
+
+    excludes = [
+        'will not show',
+        'with_index/i_will_not_show/',
+        'this is some unshown documentation',
+    ]
+    links_exist = [
+        'doc/somedocs.html',
+        'doc/',
+        'doc/with_index/index.html',
+        'doc/without_index/index.html',
+        'doc/without_index/subdir1/index.html',
+        'doc/without_index/subdir2/anotherfile.html'
+    ]
+
+    do_test_package(PKG_NAME, module_dir,
+                    includes=includes, excludes=excludes, links_exist=links_exist)


### PR DESCRIPTION
Currently, if there is an index.rst in a documentation folder, that does not override the standard directory search for documentation, which results in duplicate entries for documentation, or includes documentation folders that the user expected to be excluded since it was not included in index.rst

The heart of this PR got obscured by a lot of additional cleanup going on.

- renamed sphinx_project_directory to the more accurate rel_user_doc_directory
- reduced some of the levels shown in the documentation tree.  I don't believe in most cases it makes sense to show tree entries for the internals of documentation files.
- creation of a new test file to test the issue.

Really the heart of this is the code:
```python
        if 'index.rst' in files:
            # We assume that this index will also show any desired files in subdirectories
            dirs.clear()
```

You can see the point of this if desired by reverting the changes in `include_user_docs.py` and running the tests. The failed new test index_excudes_content  will show errors when files are shown that are not included in index.rst