### PR TITLE
Create a links.rst file so links can appear in toc

### DIFF
--- a/rosdoc2/verbs/build/builders/index.rst.jinja
+++ b/rosdoc2/verbs/build/builders/index.rst.jinja
@@ -5,16 +5,10 @@
 
 {{ package.description }}
 
-* Links
-
-  * `Rosindex <https://index.ros.org/p/{{package.name}}>`_
-{%- for link in package.urls %}
-  * `{{ link.type.capitalize() }} <{{ link.url }}>`_
-{%- endfor %}
-
 .. toctree::
    :maxdepth: 2
 
+   Links <__links>
 {% if has_python %}   Python API <modules>{% endif %}
 {% if has_cpp %}   C++ API <generated/index>{% endif %}
 {% if interface_counts['msg'] > 0 %}   Message Definitions <interfaces/message_definitions>{% endif %}

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -28,6 +28,7 @@ from ..builder import Builder
 from ..collect_inventory_files import collect_inventory_files
 from ..create_format_map_from_package import create_format_map_from_package
 from ..generate_interface_docs import generate_interface_docs
+from ..include_links import include_links
 from ..include_user_docs import include_user_docs
 from ..package_repo_url import package_repo_url
 from ..standard_documents import generate_standard_document_files, locate_standard_documents
@@ -569,6 +570,9 @@ class SphinxBuilder(Builder):
 
         # Try to locate package repo url if missing
         package_repo_url(self.build_context.package)
+
+        # generate links rst
+        include_links(self.build_context.package, wrapped_sphinx_directory)
 
         self.template_variables.update({
             'has_python': has_python,

--- a/rosdoc2/verbs/build/include_links.py
+++ b/rosdoc2/verbs/build/include_links.py
@@ -1,0 +1,36 @@
+# Copyright 2024 R. Kent James <kent@caspia.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from jinja2 import Template
+
+links_template = """
+Links
+=====
+
+.. toctree::
+
+   Rosindex <https://index.ros.org/p/{{package.name}}>
+{%- for link in package.urls %}
+   {{ link.type.capitalize() }} <{{ link.url }}>
+{%- endfor %}
+"""
+
+
+def include_links(package, output_dir):
+    """Generate an rst file containing links."""
+    links_rst = Template(links_template).render({'package': package})
+    with open(os.path.join(output_dir, '__links.rst'), 'w') as f:
+        f.write(links_rst)


### PR DESCRIPTION
Most of the top-level items on the home page also appear in the table of contents, except for links. This adds those links to the TOC.