### PR TITLE
Pin to sphinx < 8.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     pyyaml
     rosdistro
     setuptools>=40.6.0
-    sphinx
+    sphinx<8.2.0
     sphinx-rtd-theme
     myst-parser
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,8 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 keywords = rosdoc2
 
+# Pin sphinx version under 8.2 until there's a fix for
+# https://github.com/breathe-doc/breathe/issues/1022
 [options]
 python_requires = >=3.6
 install_requires =


### PR DESCRIPTION
There is a private API dependency on sphinx from breathe 4.35, and sphinx 8.2.0 changes that private API in a way that breaks breathe. This issue only appears to manifest in rosdoc2 jobs which process C++.

Example of this failure on the official buildfarm: https://build.ros2.org/view/Jdoc/job/Jdoc__rcl__ubuntu_noble_amd64/10/