### PR TITLE
Add '--version' option to print rosdoc2 version

### DIFF
--- a/rosdoc2/main.py
+++ b/rosdoc2/main.py
@@ -19,6 +19,8 @@ from osrf_pycommon.cli_utils.verb_pattern import create_subparsers
 from osrf_pycommon.cli_utils.verb_pattern import list_verbs
 from osrf_pycommon.cli_utils.verb_pattern import split_arguments_by_verb
 
+from . import __version__ as VERSION
+
 COMMAND_NAME = 'rosdoc2'
 
 VERBS_ENTRY_POINT = f'{COMMAND_NAME}.verbs'
@@ -37,6 +39,7 @@ def main(sysargs=None):
     parser = argparse.ArgumentParser(
         description=f'{COMMAND_NAME} builds documentation for ROS packages'
     )
+    parser.add_argument('--version', action='version', version=f'{COMMAND_NAME} {VERSION}')
 
     # Generate a list of verbs available
     verbs = list_verbs(VERBS_ENTRY_POINT)
@@ -56,6 +59,10 @@ def main(sysargs=None):
     # Short circuit -h and --help
     if '-h' in pre_verb_args or '--help' in pre_verb_args:
         parser.print_help()
+        sys.exit(0)
+    # Short circuit --version
+    if '--version' in pre_verb_args:
+        parser.parse_args(sysargs)
         sys.exit(0)
 
     # Error on no verb provided


### PR DESCRIPTION
I wanted to check the version myself and saw there was no `--version` option. I thought this would be useful.

```console
$ rosdoc2 --help
usage: rosdoc2 [-h] [--version] [build | default_config | open | scan] ...

rosdoc2 builds documentation for ROS packages

options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit

rosdoc2 command:
  Call `rosdoc2 [build | default_config | open | scan] -h` for help on a each verb.

  [build | default_config | open | scan]
$ rosdoc2 --version
rosdoc2 0.2.2.dev0
```

Note that `--version` can't be used with a verb:

```console
$ rosdoc2 build --help
usage: rosdoc2 build [-h] --package-path PACKAGE_PATH [--build-directory BUILD_DIRECTORY] [--install-directory INSTALL_DIRECTORY] [--cross-reference-directory CROSS_REFERENCE_DIRECTORY] [--base-url BASE_URL]
                     [--output-directory OUTPUT_DIRECTORY] [--doc-build-directory DOC_BUILD_DIRECTORY] [--debug] [--yaml-extend YAML_EXTEND]

Build the documentation of a ROS package

options:
  -h, --help            show this help message and exit
  --package-path PACKAGE_PATH, -p PACKAGE_PATH
                        path to the ROS package
  --build-directory BUILD_DIRECTORY, -b BUILD_DIRECTORY
                        UNUSED, to be removed at some time after September 1st, 2024
  --install-directory INSTALL_DIRECTORY, -i INSTALL_DIRECTORY
                        UNUSED, to be removed at some time (install directory of the package)
  --cross-reference-directory CROSS_REFERENCE_DIRECTORY, -c CROSS_REFERENCE_DIRECTORY
                        directory containing cross reference files, like tag files and inventory files
  --base-url BASE_URL, -u BASE_URL
                        The base url where the package docs will be hosted, used to configure tag files.
  --output-directory OUTPUT_DIRECTORY, -o OUTPUT_DIRECTORY
                        directory to output the documenation artifacts into
  --doc-build-directory DOC_BUILD_DIRECTORY, -d DOC_BUILD_DIRECTORY
                        directory to setup build prefix
  --debug               enable more output to debug problems
  --yaml-extend YAML_EXTEND, -y YAML_EXTEND
                        Extend rosdoc2.yaml
$ rosdoc2 build --version
usage: rosdoc2 build [-h] --package-path PACKAGE_PATH [--build-directory BUILD_DIRECTORY] [--install-directory INSTALL_DIRECTORY] [--cross-reference-directory CROSS_REFERENCE_DIRECTORY] [--base-url BASE_URL]
                     [--output-directory OUTPUT_DIRECTORY] [--doc-build-directory DOC_BUILD_DIRECTORY] [--debug] [--yaml-extend YAML_EXTEND]
rosdoc2 build: error: the following arguments are required: --package-path/-p
```