### PR TITLE
Copy templates to actual sphinx project location

### DIFF
--- a/test/packages/basic_cpp/doc/_templates/layout.html
+++ b/test/packages/basic_cpp/doc/_templates/layout.html
@@ -1,0 +1,9 @@
+{% extends "!layout.html" %}
+{% block navigation %}
+{{ super() }}
+<div class="wy-menu wy-menu-vertical">
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="https://example.net">Add me to TOC</a></li>
+</ul>
+</div>
+{% endblock %}

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -253,6 +253,7 @@ def test_basic_cpp(module_dir):
     includes = [
         'a different title',  # changed in custom index.rst
         'basic_cpp_and_more',  # changed in custom config.py
+        'add me to toc',  # added in a template
     ]
     do_test_package(PKG_NAME, module_dir, includes=includes)
 


### PR DESCRIPTION
Sphinx projects can include templates that modify how the output appears, for example adding content in a footer. This would typically by specified in a templates directory, relative to where conf.py exists.

The issue we face is that people who specify templates would typically do that in a doc/_templates directory, which is also where a conf.py file would be added (which we rename to __conf.py to avoid certain conflicts, or supply a default if missing).

However, the actual sphinx project that we run, using a conf.py that wraps either a user or a default conf.py, is run in the wrapped_sphinx_directory, not in wrapped_sphinx_directory/doc which is where the templates are. So a templates reference like '_templates' (which we define by default) is looking for the templates in wrapped_sphinx_directory/_templates, and not wrapped_sphinx_directory/doc/_templates where they are actually located.

This PR copies templates from where they exist (relative to the user's conf.py directory) to where they are needed (relative to the wrapped_sphinx_directory).

There are very few packages that are currently actually using templates. I did find one, ecal. Not a great example since they have their own complex doc generation, but they do have a template that defines a custom template. Without this patch, the footer does not get changed, but with it their custom footer gets used in all of the generated documentation.
