### PR TITLE
Revert "Pin to sphinx < 8.2.0 (#174)" as breathe has been updated.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,6 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 keywords = rosdoc2
 
-# Pin sphinx version under 8.2 until there's a fix for
-# https://github.com/breathe-doc/breathe/issues/1022
 [options]
 python_requires = >=3.6
 install_requires =
@@ -37,7 +35,7 @@ install_requires =
     pyyaml
     rosdistro
     setuptools>=40.6.0
-    sphinx<8.2.0
+    sphinx
     sphinx-rtd-theme
     myst-parser
 packages = find:


### PR DESCRIPTION
This reverts commit 95fa29de85a692ba9c312e70d8c67b912db9b47c.

Breathe has been updated now, and a more robust release procedure implemented in https://github.com/breathe-doc/breathe/pull/1023. I think we want to generally follow newer breathe and sphinx releases rather than pin to a fixed release.

I tested this, using a local venv, by first confirming that I could reproduce the original error by running rosdoc2 on jazzy rcl forcing breathe 4.35.0, then confirming that the error goes away with this PR.