### PR TITLE
Allow user to specify index.rst in package directory

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -555,10 +555,14 @@ class SphinxBuilder(Builder):
             except OSError as e:
                 print(f'Failed to copy user content: {e}')
         else:
-            # copy jinja file if it exists
+            # copy index file if it exists
             index_jinja_path = os.path.join(package_xml_directory, 'index.rst.jinja')
             if os.path.isfile(index_jinja_path):
                 shutil.copy(index_jinja_path, wrapped_sphinx_directory)
+            else:
+                index_path = os.path.join(package_xml_directory, 'index.rst')
+                if os.path.isfile(index_path):
+                    shutil.copy(index_path, wrapped_sphinx_directory)
 
             # include user documentation
             if self.user_doc_dir == IGNORE_DOC_DIRECTORY:

--- a/test/packages/user_index_root/index.rst
+++ b/test/packages/user_index_root/index.rst
@@ -1,0 +1,18 @@
+user_index_root
+===============
+
+User specified index.rst without sphinx_sourcedir
+
+* Links
+
+  * `index.rst user link <https://example.org/the_link>`_
+
+.. toctree::
+   :maxdepth: 2
+
+   Standard Documents <_standards>
+
+.. toctree::
+   :hidden:
+
+   genindex

--- a/test/packages/user_index_root/package.xml
+++ b/test/packages/user_index_root/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>user_index_root</name>
+  <version>0.1.2</version>
+  <description>User specified index.rst without sphinx_sourcedir</description>
+  <maintainer email="someone@example.com">Some One</maintainer>
+  <license>Apache License 2.0</license>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -360,6 +360,19 @@ def test_user_jinja_root(module_dir):
                     includes=includes)
 
 
+def test_user_index_root(module_dir):
+    PKG_NAME = 'user_index_root'
+    do_build_package(DATAPATH / PKG_NAME, module_dir)
+
+    includes = [
+        PKG_NAME,
+        'index.rst user link',  # a non-standard link from a user-supplied index.rst
+    ]
+
+    do_test_package(PKG_NAME, module_dir,
+                    includes=includes)
+
+
 def test_user_jinja_sphinx_sourcedir(module_dir):
     PKG_NAME = 'user_jinja_sphinx_sourcedir'
     do_build_package(DATAPATH / PKG_NAME, module_dir)


### PR DESCRIPTION
Fixes https://github.com/rkent/rosdoc2/issues/4

We currently support an index.rst.jinja in the package directory, but I'd always intended to also support index.rst there. This fixes that.