### PR TITLE
Show rosdistro in TOC

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -279,6 +279,10 @@ default_conf_py_template = """\
 # -- Project information -----------------------------------------------------
 
 project = '{package.name}'
+ros_distro = os.environ.get('ROS_DISTRO')
+if ros_distro:
+    project += ': ' + ros_distro.capitalize()
+
 # TODO(tfoote) The docs say year and author but we have this and it seems more relevant.
 copyright = 'The <{package.name}> Contributors. License: {package_licenses}'
 author = \"\"\"{package_authors}\"\"\"

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -340,6 +340,7 @@ def test_rclcpp(module_dir):
 
     includes = [
         PKG_NAME,
+        'rclcpp: rolling'  # Confirm that rosdistro is appended to the title in the TOC.
     ]
 
     links_exist = ['https://github.com/ros2/rclcpp.git']  # Found repo url from rosdistro.


### PR DESCRIPTION
Since we now have ROS_DISTRO available, this shows the distro in the form '<package_name>: Rolling' following the format in the main ros documentation at https://docs.ros.org/en/rolling/