### PR TITLE
doc/index.rst should override glob of doc/ files

### DIFF
--- a/rosdoc2/verbs/build/include_user_docs.py
+++ b/rosdoc2/verbs/build/include_user_docs.py
@@ -27,7 +27,7 @@ Documentation
    :titlesonly:
    :glob:
 
-   {rel_user_doc_directory}/*
+   {rel_user_doc_directory}/{files}
 """
 
 subdirectory_rst_template = """\
@@ -83,8 +83,11 @@ def include_user_docs(rel_user_doc_directory: str,
 
     logger.info(f'Documentation found in directories {doc_directories}')
 
+    toc_files = '*'
+    if os.path.isfile(os.path.join(user_doc_directory, 'index.rst')):
+        toc_files = 'index'
     toc_content = documentation_rst_template.format_map(
-        {'rel_user_doc_directory': rel_user_doc_directory})
+        {'rel_user_doc_directory': rel_user_doc_directory, 'files': toc_files})
     # generate a glob rst entry for each directory with documents
     for relpath in doc_directories:
         # files that will be explicitly listed in index.rst

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -254,8 +254,12 @@ def test_basic_cpp(module_dir):
         'a different title',  # changed in custom index.rst
         'basic_cpp_and_more',  # changed in custom config.py
         'add me to toc',  # added in a template
+        'welcome to the documentation for basic_cpp',  # from doc/index.rst
     ]
-    do_test_package(PKG_NAME, module_dir, includes=includes)
+
+    excludes = 'overview'  # should not show rst files from doc/
+
+    do_test_package(PKG_NAME, module_dir, includes=includes, excludes=excludes)
 
     # Previously, running rosdoc2 would create a 'generated' folder in the doc
     # subdirectory of the package. Directory refactoring should have eliminated


### PR DESCRIPTION
Fixes https://github.com/rkent/rosdoc2/issues/41

I'm going through my list of issues, doing easy fixes.

If a user specifies an index.rst file in their doc folder, we should assume that contains everything needed to show the documentation in that folder. Currently, we are treating that like any other documentation file, that is it is included in a list of all of the other document files in that folder. With this change, if the index.rst file exists, only it is shown, and we assume that the user provided a link to whatever else they care about in that file.