### PR TITLE
Document testing

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -1,0 +1,22 @@
+# Testing
+
+To install rosdoc2 prerequisites for testing, run (preferably in a virtual environment)
+```bash
+pip install ---upgrade --editable .[test]
+```
+
+After install with the test option, you can run tests (from the rosdoc2 directory) with:
+```bash
+pytest
+```
+If you want to see more output, try the ```-rP``` and/or ```--log-level=DEBUG``` option.
+
+To limit to a particular test, for example the test of "full_package", use ```-k full_package```
+
+Combining these as an example, to get detailed output from the full_package test even for
+passed tests, run:
+```bash
+pytest -rP --log-level=DEBUG -k full_package
+```
+
+Testing generates files in a temporary directory, typically at `/tmp/pytest-of-USERNAME`


### PR DESCRIPTION
This PR adds documentation for testing.

I want to start landing the documentation for the current version of rosdoc2. I wrote a bunch of  documentation several months ago in a branch https://github.com/rkent/rosdoc2/tree/major-documentation-rewrite. This is one file from that branch.

Is it OK if we land these one at a time (like in this PR), or would you rather bunch them into a big documentation PR?

I've been avoiding reviewing my documentation rewrite myself, while I found this one file fairly easy to test and add. So I would prefer one file at a time.