### PR TITLE
Link to the 'Documenting a ROS 2 package' guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Additionally, if your package is laid out in a standard way then it will automat
 However, if you need to place your files in non-standard locations, configure Sphinx and/or Doxygen beyond the defaults, or do something else, you will need to create a `rosdoc2.yaml` file and reference it from your package's `package.xml`.
 How to do that, and how to handle some other special cases will follow.
 
+Also refer to the [Documenting a ROS 2 package how-to guide in the ROS 2 docs](https://docs.ros.org/en/rolling/How-To-Guides/Documenting-a-ROS-2-Package.html).
+
 #### Using a `rosdoc2.yaml` file to control how your package is documented
 
 To generate a default config file, run


### PR DESCRIPTION
I noticed that the [how-to guide](https://docs.ros.org/en/rolling/How-To-Guides/Documenting-a-ROS-2-Package.html) is not mentioned here. It has some pretty useful information, so I thought it would be good to link to it here.

Note that some of the empty/TODO sub-sections under [Documenting a Package](https://github.com/ros-infrastructure/rosdoc2#documenting-a-package) in the README here are covered by the guide. Not sure if the intention is to also document that here, but for now we can just start with this link.