### PR TITLE
Extend user-provided autodoc mock imports

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -162,7 +162,8 @@ if rosdoc2_settings.get('enable_autodoc', True):
     autodoc_mock_imports.extend(pkgs_to_mock)
 
     if len(autodoc_mock_imports) > 0:
-        print(f"[rosdoc2] autodoc mock imports: '{{'\\', \\''.join(autodoc_mock_imports)}}'")
+        joined_imports = "', '".join(autodoc_mock_imports)
+        print(f"[rosdoc2] autodoc mock imports: '{{joined_imports}}'")
 
 if rosdoc2_settings.get('enable_intersphinx', True):
     print('[rosdoc2] enabling intersphinx')


### PR DESCRIPTION
Sometimes adding mock imports from exec dependencies is not enough as not every rosdep key translates directly to the Python package name. For example `python3-opencv` provides `cv2` package.

Currently it is impossible for the user to provide `autodoc_mock_imports` in the `conf.py` as they are overwritten by the wrapper `conf.py`. This PR modifies the wrapper `conf.py` to extend the user-provided `autodoc_mock_imports` instead of overwriting them.