### PR TITLE
Move all required conf.py variables to generated wrapped conf.py so default user conf.py is blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Command-line tool for generating documentation for ROS 2 packages.
 
 ## Quick-start
 
-This tool can be viewed from two perspectives: first from the perspective of a user wanting to building documentation for any given ROS 2 package in order to view it, and second from the perspective of package maintainers who need to write their documentation and configure how this tool works on their package.
+This tool can be viewed from two perspectives: first from the perspective of a user wanting to build documentation for any given ROS 2 package in order to view it, and second from the perspective of package maintainers who need to write their documentation and configure how this tool works on their package.
 
 ### Build documentation for a ROS 2 package
 
@@ -25,7 +25,11 @@ The package directory that you specify must contain a single ROS 2 package that 
 There will be an `index.html` file in the output directory which you can open manually, or with this command:
 
 ```
-rosdoc2 open ./doc_output/index.html
+rosdoc2 open ./docs_output
+```
+then click through to the package name, then `index.html`. Or you can do that directly, filling in the package name, using:
+```
+rosdoc2 open ./docs_output/<package_name>/index.html
 ```
 
 For more advanced usage see the documentation.
@@ -38,13 +42,33 @@ python3 -m rosdoc2.main <options>
 
 ### Set up a ROS 2 package to be used with this tool
 
-In many cases, C/C++ packages require no configuration, and will work if you simply layout your package in a standard configuration and the tool will do the rest.
+In many cases, C/C++ or python packages require no configuration, and will work if you simply
+layout your package in a standard configuration and the tool will do the rest.
 
-However, if you want to provide additional documentation, like a conceptual overview or tutorials, then you will want to provide a Sphinx `conf.py` file and do that documentation in `.rst` files using Sphinx.
+If you want to provide additional documentation, like a conceptual overview or tutorials,
+you can provide those files in either restructured text (.rst) or markdown (.md) in a `doc/` folder.
+It is also highly recommended that you provide a README file, which will be rendered on the package
+documentation front page by rosdoc2 (and also by the other ROS documentation tool, rosindex).
 
-Additionally, if you have a Python API then you will want to provide a Sphinx `conf.py`
+Currently, official documentation builds for released packages are done automatically by the build system,
+placing results under `https://docs.ros.org/en/<distro>/p/` for example [rolling](https://docs.ros.org/en/rolling/p/)
 
 ## Installation
+
+The official package documentation builds install rosdoc2 directly from its git repository, so the best way to test with rosdoc2 is
+to install from source. Other methods are also available, though the rosdoc2 version there may be older.
+
+### Installation from source
+
+We recommend you install and use rosdoc2 it from a [virtualenv](https://docs.python.org/3/library/venv.html).
+
+To install:
+
+```
+python3 -m pip install --upgrade 'git+https://github.com/ros-infrastructure/rosdoc2@main'
+```
+
+### Installation from ROS repositories
 
 `rosdoc2` can be installed from the [ROS repositories](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html#enable-required-repositories).
 
@@ -52,22 +76,13 @@ Additionally, if you have a Python API then you will want to provide a Sphinx `c
 apt install -y python3-rosdoc2
 ```
 
-#### Installation from PyPI
+### Installation from PyPI
 
 You may also install rosdoc2 from [PyPI](https://pypi.org/project/rosdoc2).
 If you do so, we recommend you install and use it from a [virtualenv](https://docs.python.org/3/library/venv.html).
 
 ```
 python3 -m pip install rosdoc2
-```
-
-#### Installation from source
-
-You can also use pip to install rosdoc2 from source.
-Again, we recommend you install and use it from a [virtualenv](https://docs.python.org/3/library/venv.html).
-
-```
-python3 -m pip install --upgrade 'git+https://github.com/ros-infrastructure/rosdoc2@main'
 ```
 
 ## Documentation
@@ -102,8 +117,6 @@ Some features were kept in mind while initially developing this tool, but are no
 Including:
 
 - extensible "builders", so that other kinds of documentation tools can be supported in the future
-- documenting packages without first building them, if the package does not require it
-  - packages with generated code, including packages with ROS 2 Messages, need to be built first, but many do not need to be
 - using this tool in automated testing and/or CI
 
 ### Building Documentation for a Package

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -56,251 +56,6 @@ from importlib.metadata import entry_points
 if '{python_src_directory}' != 'None':
     sys.path.insert(0, os.path.abspath(os.path.join('{python_src_directory}', '..')))
 
-## exec the user's conf.py to bring all of their settings into this file.
-confpy_succeeded = False
-templates_path = []
-
-if os.path.isfile('{user_conf_py_filename}'):
-    try:
-        exec(open("{user_conf_py_filename}").read())
-        confpy_succeeded = True
-        print('[rosdoc2] Using user supplied conf.py')
-    except Exception as e:
-        print(f'[rosdoc2] *** Warning *** conf.py for package {package_name} generated error: '
-              + str(e) + '. Falling back to default generated conf.py.')
-if not confpy_succeeded:
-    exec(open("{default_conf_py_filename}").read())
-
-## Copy any templates to the wrapped location.
-for t_dir in templates_path:
-    source_t_dir = os.path.join('{conf_py_directory}', t_dir)
-    target_t_dir = os.path.join('{wrapped_sphinx_directory}', t_dir)
-    if os.path.isdir(target_t_dir):
-        # Template already copied
-        pass
-    elif os.path.isdir(source_t_dir):
-        shutil.copytree(source_t_dir, target_t_dir)
-
-def ensure_global(name, default):
-    if name not in globals():
-        globals()[name] = default
-
-## Based on the rosdoc2 settings, do various things to the settings before
-## letting Sphinx continue.
-
-ensure_global('rosdoc2_settings', {{}})
-ensure_global('extensions', [])
-ensure_global('project', "{package_name}")
-ensure_global('author', \"\"\"{package_authors}\"\"\")
-ensure_global('release', "{package.version}")
-ensure_global('version', "{package_version_short}")
-ensure_global('html_theme', 'sphinx_rtd_theme')
-ensure_global('autodoc_mock_imports', [])
-
-# Remove any unsupported extensions
-allowed_extensions = set((
-    # Shipped with sphinx
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosectionlabel',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.coverage',
-    'sphinx.ext.doctest',
-    'sphinx.ext.duration',
-    'sphinx.ext.extlinks',
-    'sphinx.ext.githubpages',
-    'sphinx.ext.graphviz',
-    'sphinx.ext.ifconfig',
-    'sphinx.ext.imgconverter',
-    'sphinx.ext.inheritance_diagram',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.linkcode',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.todo',
-    'sphinx.ext.viewcode',
-    # Sphinx-included math extensions
-    'sphinx.ext.imgmath',
-    'sphinx.ext.mathjax',
-    # Installed by us
-    'myst_parser',
-    'sphinx_rtd_theme',
-))
-
-if not {disable_breathe}:
-    allowed_extensions.add(('breathe', 'exhale'))
-else:
-    rosdoc2_settings['enable_breathe'] = False
-    rosdoc2_settings['enable_exhale'] = False
-
-for extension in extensions[:]:
-    if extension not in allowed_extensions:
-        if rosdoc2_settings.get('allow_other_extensions', False):
-            print(f"[rosdoc2] Checking if extension '{{extension}}' is installed")
-            try:
-                __import__(extension)
-                continue
-            except ModuleNotFoundError:
-                print(f"[rosdoc2] requested extension '{{extension}}' not installed")
-        print(f"[rosdoc2] *** Warning *** removing extension '{{extension}}', not supported")
-        extensions.remove(extension)
-if extensions:
-    print(f'[rosdoc2] user conf.py specified allowed extensions: {{extensions}}')
-
-if rosdoc2_settings.get('enable_autodoc', True):
-    print('[rosdoc2] enabling autodoc')
-    extensions.append('sphinx.ext.autodoc')
-
-    pkgs_to_mock = []
-    import importlib
-    for exec_depend in {exec_depends}:
-        try:
-            # Some python dependencies may be dist packages.
-            exec_depend = exec_depend.split("python3-")[-1]
-            importlib.import_module(exec_depend)
-        except ImportError:
-            pkgs_to_mock.append(exec_depend)
-
-    autodoc_mock_imports.extend(pkgs_to_mock)
-
-    if len(autodoc_mock_imports) > 0:
-        joined_imports = "', '".join(autodoc_mock_imports)
-        print(f"[rosdoc2] autodoc mock imports: '{{joined_imports}}'")
-
-if rosdoc2_settings.get('enable_intersphinx', True):
-    print('[rosdoc2] enabling intersphinx')
-    extensions.append('sphinx.ext.intersphinx')
-
-build_type = '{build_type}'
-always_run_doxygen = {always_run_doxygen}
-# By default, the `exhale`/`breathe` extensions should be added if `doxygen` was invoked
-is_doxygen_invoked = {did_run_doxygen}
-
-if rosdoc2_settings.get('enable_breathe', is_doxygen_invoked):
-    # Configure Breathe.
-    # Breathe ingests the XML output from Doxygen and makes it accessible from Sphinx.
-    print('[rosdoc2] enabling breathe')
-    # First check that doxygen would have been run
-    if not is_doxygen_invoked:
-        raise RuntimeError(
-            "Cannot enable the 'breathe' extension if 'doxygen' is not invoked. "
-            "Please enable 'always_run_doxygen' if the package is not an "
-            "'ament_cmake' or 'cmake' package.")
-    ensure_global('breathe_projects', {{}})
-    breathe_projects.update({{{breathe_projects}}})
-    if breathe_projects:
-        # Enable Breathe and arbitrarily select the first project.
-        extensions.append('breathe')
-        breathe_default_project = next(iter(breathe_projects.keys()))
-
-if rosdoc2_settings.get('enable_exhale', is_doxygen_invoked):
-    # Configure Exhale.
-    # Exhale uses the output of Doxygen and Breathe to create easier to browse pages
-    # for classes and functions documented with Doxygen.
-    # This is similar to the class hierarchies and namespace listing provided by
-    # Doxygen out of the box.
-    print('[rosdoc2] enabling exhale')
-    # First check that doxygen would have been run
-    if not is_doxygen_invoked:
-        raise RuntimeError(
-            "Cannot enable the 'breathe' extension if 'doxygen' is not invoked. "
-            "Please enable 'always_run_doxygen' if the package is not an "
-            "'ament_cmake' or 'cmake' package.")
-    extensions.append('exhale')
-    ensure_global('exhale_args', {{}})
-
-    default_exhale_specs_mapping = {{
-        'page': [':content-only:'],
-        **dict.fromkeys(
-            ['class', 'struct'],
-            [':members:', ':protected-members:', ':undoc-members:']),
-    }}
-
-    exhale_specs_mapping = rosdoc2_settings.get(
-        'exhale_specs_mapping', default_exhale_specs_mapping)
-
-    from exhale import utils
-    exhale_args.update({{
-        # These arguments are required.
-        "containmentFolder": "{wrapped_sphinx_directory}/generated",
-        "rootFileName": "index.rst",
-        "rootFileTitle": "C++ API",
-        "doxygenStripFromPath": "..",
-        # Suggested optional arguments.
-        "createTreeView": True,
-        "fullToctreeMaxDepth": 1,
-        "unabridgedOrphanKinds": [],
-        "fullApiSubSectionTitle": "Full C++ API",
-        # TIP: if using the sphinx-bootstrap-theme, you need
-        # "treeViewIsBootstrap": True,
-        "exhaleExecutesDoxygen": False,
-        # Maps markdown files to the "md" lexer, and not the "markdown" lexer
-        # Pygments registers "md" as a valid markdown lexer, and not "markdown"
-        "lexerMapping": {{r".*\\.(md|markdown)$": "md",}},
-        "customSpecificationsMapping": utils.makeCustomSpecificationsMapping(
-            lambda kind: exhale_specs_mapping.get(kind, [])),
-    }})
-
-use_user_theme = False
-if not rosdoc2_settings.get('override_theme', True) and html_theme != 'sphinx_rtd_theme':
-    ## Detect if requested theme exists
-    for entry_point in entry_points(group='sphinx.html_themes'):
-        if entry_point.name == html_theme:
-            use_user_theme = True
-            break
-    if not use_user_theme:
-        print(f"[rosdoc2] *** warning *** user specified theme '{{html_theme}}' not found")
-if not use_user_theme:
-    extensions.append('sphinx_rtd_theme')
-    html_theme = 'sphinx_rtd_theme'
-    print(f"[rosdoc2] overriding theme to be '{{html_theme}}'")
-else:
-    print(f"[rosdoc2] Using user specified theme '{{html_theme}}'")
-
-if rosdoc2_settings.get('automatically_extend_intersphinx_mapping', True):
-    print(f"[rosdoc2] extending intersphinx mapping")
-    if 'sphinx.ext.intersphinx' not in extensions:
-        raise RuntimeError(
-            "Cannot extend intersphinx mapping if 'sphinx.ext.intersphinx' "
-            "has not been added to the extensions")
-    ensure_global('intersphinx_mapping', {{
-        {intersphinx_mapping_extensions}
-    }})
-
-if rosdoc2_settings.get('support_markdown', True):
-    print(f"[rosdoc2] adding markdown parser")
-    # The `myst_parser` is used specifically if there are markdown files
-    # in the sphinx project
-    extensions.append('myst_parser')
-
-if {show_doxygen_html} and {has_cpp}:
-    templates_path.append('__doxy_template')
-"""  # noqa: W605 B902
-
-default_conf_py_template = """\
-## Generated by rosdoc2.verbs.build.builders.SphinxBuilder.
-## Based on a recent output from Sphinx-quickstart.
-
-# Configuration file for the Sphinx documentation builder.
-#
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
-
-# -- Path setup --------------------------------------------------------------
-
-# rosdoc2 runs sphinx in a wrapping directory so that output does not contaminate
-# the source repository. But that can make figuring out the proper path to
-# python files tricky in conf.py. Normally you do not have to set this in a custom
-# conf.py, as the proper directory is set in a wrapping conf.py (based on the project's
-# 'python_source' which by default is the package name). Unfortunately there is no general
-# way to do that in a custom conf.py (as it depends on where docs_build is located), so we do
-# not recommend sys.path be modified here.
-#
-# If for some reason you must set a path here, follow this pattern:
-#
-#import os
-#import sys
-#sys.path.insert(0, '<absolute path to python source directory>/..')
-
 # -- Project information -----------------------------------------------------
 
 project = '{package.name}'
@@ -308,15 +63,13 @@ ros_distro = os.environ.get('ROS_DISTRO')
 if ros_distro:
     project += ': ' + ros_distro.capitalize()
 
-# TODO(tfoote) The docs say year and author but we have this and it seems more relevant.
+# The docs say year and author but we have this and it seems more relevant.
 copyright = 'The <{package.name}> Contributors. License: {package_licenses}'
 author = \"\"\"{package_authors}\"\"\"
 
 # The full version, including alpha/beta/rc tags
 release = '{package.version}'
-
 version = '{package_version_short}'
-
 
 # -- General configuration ---------------------------------------------------
 
@@ -348,8 +101,11 @@ exclude_patterns = []
 ## here if your code has dependencies not listed in package.xml or if the module
 ## name differs from the package name.
 autodoc_mock_imports = []
-
+pkgs_to_mock = []
+exhale_args = {{}}
+breathe_projects = {{}}
 master_doc = 'index'
+intersphinx_mapping = {{ {intersphinx_mapping_extensions} }}
 
 source_suffix = {{
     '.rst': 'restructuredtext',
@@ -430,6 +186,226 @@ rosdoc2_settings = {{
     ## extensions loaded by default by Sphinx or rosdoc2 installs are allowed.
     # 'allow_other_extensions': False,
 }}
+
+## exec the user's conf.py to bring all of their settings into this file.
+confpy_succeeded = False
+templates_path = []
+
+if os.path.isfile('{user_conf_py_filename}'):
+    try:
+        exec(open("{user_conf_py_filename}").read())
+        confpy_succeeded = True
+        print('[rosdoc2] Using user supplied conf.py')
+    except Exception as e:
+        print(f'[rosdoc2] *** Warning *** conf.py for package {package_name} generated error: '
+              + str(e) + '. Falling back to default generated conf.py.')
+if not confpy_succeeded:
+    exec(open("{default_conf_py_filename}").read())
+
+## Copy any templates to the wrapped location.
+for t_dir in templates_path:
+    source_t_dir = os.path.join('{conf_py_directory}', t_dir)
+    target_t_dir = os.path.join('{wrapped_sphinx_directory}', t_dir)
+    if os.path.isdir(target_t_dir):
+        # Template already copied
+        pass
+    elif os.path.isdir(source_t_dir):
+        shutil.copytree(source_t_dir, target_t_dir)
+
+## Based on the rosdoc2 settings, do various things to the settings before
+## letting Sphinx continue.
+
+# Remove any unsupported extensions
+allowed_extensions = set((
+    # Shipped with sphinx
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosectionlabel',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.coverage',
+    'sphinx.ext.doctest',
+    'sphinx.ext.duration',
+    'sphinx.ext.extlinks',
+    'sphinx.ext.githubpages',
+    'sphinx.ext.graphviz',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.imgconverter',
+    'sphinx.ext.inheritance_diagram',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.linkcode',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.todo',
+    'sphinx.ext.viewcode',
+    # Sphinx-included math extensions
+    'sphinx.ext.imgmath',
+    'sphinx.ext.mathjax',
+    # Installed by us
+    'myst_parser',
+    'sphinx_rtd_theme',
+))
+
+if not {disable_breathe}:
+    allowed_extensions.add(('breathe', 'exhale'))
+else:
+    rosdoc2_settings['enable_breathe'] = False
+    rosdoc2_settings['enable_exhale'] = False
+
+for extension in extensions[:]:
+    if extension not in allowed_extensions:
+        if rosdoc2_settings.get('allow_other_extensions', False):
+            print(f"[rosdoc2] Checking if extension '{{extension}}' is installed")
+            try:
+                __import__(extension)
+                continue
+            except ModuleNotFoundError:
+                print(f"[rosdoc2] requested extension '{{extension}}' not installed")
+        print(f"[rosdoc2] *** Warning *** removing extension '{{extension}}', not supported")
+        extensions.remove(extension)
+if extensions:
+    print(f'[rosdoc2] user conf.py specified allowed extensions: {{extensions}}')
+
+if rosdoc2_settings.get('enable_autodoc', True):
+    print('[rosdoc2] enabling autodoc')
+    extensions.append('sphinx.ext.autodoc')
+
+    import importlib
+    for exec_depend in {exec_depends}:
+        try:
+            # Some python dependencies may be dist packages.
+            exec_depend = exec_depend.split("python3-")[-1]
+            importlib.import_module(exec_depend)
+        except ImportError:
+            pkgs_to_mock.append(exec_depend)
+
+    autodoc_mock_imports.extend(pkgs_to_mock)
+
+    if len(autodoc_mock_imports) > 0:
+        joined_imports = "', '".join(autodoc_mock_imports)
+        print(f"[rosdoc2] autodoc mock imports: '{{joined_imports}}'")
+
+if rosdoc2_settings.get('enable_intersphinx', True):
+    print('[rosdoc2] enabling intersphinx')
+    extensions.append('sphinx.ext.intersphinx')
+
+build_type = '{build_type}'
+always_run_doxygen = {always_run_doxygen}
+# By default, the `exhale`/`breathe` extensions should be added if `doxygen` was invoked
+is_doxygen_invoked = {did_run_doxygen}
+
+if rosdoc2_settings.get('enable_breathe', is_doxygen_invoked):
+    # Configure Breathe.
+    # Breathe ingests the XML output from Doxygen and makes it accessible from Sphinx.
+    print('[rosdoc2] enabling breathe')
+    # First check that doxygen would have been run
+    if not is_doxygen_invoked:
+        raise RuntimeError(
+            "Cannot enable the 'breathe' extension if 'doxygen' is not invoked. "
+            "Please enable 'always_run_doxygen' if the package is not an "
+            "'ament_cmake' or 'cmake' package.")
+    breathe_projects.update({{{breathe_projects}}})
+    if breathe_projects:
+        # Enable Breathe and arbitrarily select the first project.
+        extensions.append('breathe')
+        breathe_default_project = next(iter(breathe_projects.keys()))
+
+if rosdoc2_settings.get('enable_exhale', is_doxygen_invoked):
+    # Configure Exhale.
+    # Exhale uses the output of Doxygen and Breathe to create easier to browse pages
+    # for classes and functions documented with Doxygen.
+    # This is similar to the class hierarchies and namespace listing provided by
+    # Doxygen out of the box.
+    print('[rosdoc2] enabling exhale')
+    # First check that doxygen would have been run
+    if not is_doxygen_invoked:
+        raise RuntimeError(
+            "Cannot enable the 'breathe' extension if 'doxygen' is not invoked. "
+            "Please enable 'always_run_doxygen' if the package is not an "
+            "'ament_cmake' or 'cmake' package.")
+    extensions.append('exhale')
+
+    default_exhale_specs_mapping = {{
+        'page': [':content-only:'],
+        **dict.fromkeys(
+            ['class', 'struct'],
+            [':members:', ':protected-members:', ':undoc-members:']),
+    }}
+
+    exhale_specs_mapping = rosdoc2_settings.get(
+        'exhale_specs_mapping', default_exhale_specs_mapping)
+
+    from exhale import utils
+    exhale_args.update({{
+        # These arguments are required.
+        "containmentFolder": "{wrapped_sphinx_directory}/generated",
+        "rootFileName": "index.rst",
+        "rootFileTitle": "C++ API",
+        "doxygenStripFromPath": "..",
+        # Suggested optional arguments.
+        "createTreeView": True,
+        "fullToctreeMaxDepth": 1,
+        "unabridgedOrphanKinds": [],
+        "fullApiSubSectionTitle": "Full C++ API",
+        # TIP: if using the sphinx-bootstrap-theme, you need
+        # "treeViewIsBootstrap": True,
+        "exhaleExecutesDoxygen": False,
+        # Maps markdown files to the "md" lexer, and not the "markdown" lexer
+        # Pygments registers "md" as a valid markdown lexer, and not "markdown"
+        "lexerMapping": {{r".*\\.(md|markdown)$": "md",}},
+        "customSpecificationsMapping": utils.makeCustomSpecificationsMapping(
+            lambda kind: exhale_specs_mapping.get(kind, [])),
+    }})
+
+use_user_theme = False
+if not rosdoc2_settings.get('override_theme', True) and html_theme != 'sphinx_rtd_theme':
+    ## Detect if requested theme exists
+    for entry_point in entry_points(group='sphinx.html_themes'):
+        if entry_point.name == html_theme:
+            use_user_theme = True
+            break
+    if not use_user_theme:
+        print(f"[rosdoc2] *** warning *** user specified theme '{{html_theme}}' not found")
+if not use_user_theme:
+    extensions.append('sphinx_rtd_theme')
+    html_theme = 'sphinx_rtd_theme'
+    print(f"[rosdoc2] overriding theme to be '{{html_theme}}'")
+else:
+    print(f"[rosdoc2] Using user specified theme '{{html_theme}}'")
+
+if rosdoc2_settings.get('automatically_extend_intersphinx_mapping', True):
+    print(f"[rosdoc2] extending intersphinx mapping")
+    if 'sphinx.ext.intersphinx' not in extensions:
+        raise RuntimeError(
+            "Cannot extend intersphinx mapping if 'sphinx.ext.intersphinx' "
+            "has not been added to the extensions")
+
+if rosdoc2_settings.get('support_markdown', True):
+    print(f"[rosdoc2] adding markdown parser")
+    # The `myst_parser` is used specifically if there are markdown files
+    # in the sphinx project
+    extensions.append('myst_parser')
+
+if {show_doxygen_html} and {has_cpp}:
+    templates_path.append('__doxy_template')
+"""  # noqa: W605 B902
+
+default_conf_py = """\
+## Generated by rosdoc2.verbs.build.builders.SphinxBuilder.
+
+# Configuration file for the Sphinx documentation builder.
+
+# rosdoc2 runs sphinx in a wrapping directory so that output does not contaminate
+# the source repository. The wrapping directory includes a 'wrapping' conf.py file
+# which imports this file or a user-provided version, and extends it to support
+# Breathe and Exhale.
+#
+# This default file is used if the user does not provide their own conf.py file.
+# The minimal content of this file, as you can see below, is nothing, as standard
+# defaults which work with ros documentation generation are provided in the
+# wrapping conf.py file. We recommend that, if you provide your own conf.py file,
+# that you only include settings that you want to change from the defaults.
+#
+# If you want to see what the defaults are, you can run rosdoc2 on a package, and
+# look at the generated conf.py file in the build folder under the package's
+# documentation build folder.
 """
 
 # Special value for user_doc_dir if specified to ignore
@@ -810,7 +786,7 @@ class SphinxBuilder(Builder):
         })
 
         with open(os.path.join(conf_py_directory, '__conf_default.py'), 'w') as f:
-            f.write(default_conf_py_template.format_map(self.template_variables))
+            f.write(default_conf_py)
 
     def generate_wrapping_rosdoc2_sphinx_project_into_directory(
         self,

--- a/test/packages/full_package/doc/conf.py
+++ b/test/packages/full_package/doc/conf.py
@@ -1,0 +1,1 @@
+# This file is intentionally empty to test that empty is correctly handled.


### PR DESCRIPTION
Currently, the default user `conf.py` that is generated includes things like the package version, which must then be manually updated to match the version in `package.xml`.  Frequently this is not done, so there is a version mismatch.

Really there is no reason currently why `version =` is recommended in `conf.py` as that is set automatically by the wrapping `conf.py`.  But it is unclear to users (and to me for that matter) what is really required in a user-defined `conf.py`.

So this PR moves all of the required settings for `conf.py` to the wrapping `conf.py`, so that the correct, default user `conf.py` is simply blank. That way, package authors can be encouraged to only include changed or extra variables in their `conf.py`

This PR got expanded with a few cleanups that this change encouraged, plus changes in the `README` to remove unnecessary recommendations to create a user `conf.py` in certain circumstances (pus a few drive-by changes to `README` in the process.
