### PR TITLE
Show ros package dependencies.

### DIFF
--- a/rosdoc2/verbs/build/builders/index.rst.jinja
+++ b/rosdoc2/verbs/build/builders/index.rst.jinja
@@ -17,6 +17,7 @@
 {% if interface_counts['srv'] > 0 %}   Service Definitions <__service_definitions>{% endif %}
 {% if interface_counts['action'] > 0 %}   Action Definitions <__action_definitions>{% endif %}
 {% if has_standard_docs %}   Standard Documents <__standards>{% endif %}
+{% if package_depends | length > 0 %}   Ros Package Dependencies <__ros_package_dependencies>{% endif %}
 {% if external_doc_url %}
    Documentation <{{ external_doc_url }}>
 {% elif has_documentation %}

--- a/rosdoc2/verbs/build/generate_ros_package_dependencies.py
+++ b/rosdoc2/verbs/build/generate_ros_package_dependencies.py
@@ -1,0 +1,48 @@
+# Copyright 2025 R. Kent James <kent@caspia.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Generate rst file ros package dependencies."""
+
+import os
+
+from jinja2 import Template
+
+depends_fm_rst = """\
+ROS Package Dependencies
+========================
+
+.. toctree::
+    :maxdepth: 2
+    {% for package_depend in package_depends %}
+    {{ package_depend }} <https://docs.ros.org/en/{{ rosdistro }}/p/{{ package_depend }}/>
+    {% endfor %}
+"""
+
+
+def generate_ros_package_dependencies(output_dir: str, package_depends: list[str], rosdistro: str):
+    """
+    Generate rst file for ros package dependencies.
+
+    :param str output_dir: Directory path to write output
+    :param list[str] package_depends: List of package dependencies
+    :param str rosdistro: Name of ROS distribution
+    """
+    depends_rst = Template(depends_fm_rst).render({
+        'package_depends': package_depends,
+        'rosdistro': rosdistro,
+    })
+    toc_path = os.path.join(output_dir, '__ros_package_dependencies.rst')
+    with open(toc_path, 'w') as f:
+        f.write(depends_rst)

--- a/test/packages/full_package/package.xml
+++ b/test/packages/full_package/package.xml
@@ -15,6 +15,7 @@
 
   <depend>rclcpp</depend>
   <depend>rclpy</depend>
+  <depend>eigen</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -119,6 +119,7 @@ def test_minimum_package(module_dir):
 def test_full_package(module_dir):
     """Test a package with C++, python, and docs."""
     PKG_NAME = 'full_package'
+    os.environ['ROS_DISTRO'] = 'rolling'  # Needed for package dependencies
     do_build_package(DATAPATH / PKG_NAME, module_dir)
 
     do_test_full_package(module_dir)
@@ -127,6 +128,7 @@ def test_full_package(module_dir):
 def test_default_yaml(module_dir):
     """Test a package with C++, python, and docs using specified default rosdoc2.yaml configs."""
     PKG_NAME = 'default_yaml'
+    os.environ['ROS_DISTRO'] = 'rolling'  # Needed for package dependencies
     do_build_package(DATAPATH / PKG_NAME, module_dir, with_extension=True)
 
     do_test_full_package(module_dir, pkg_name=PKG_NAME)

--- a/test/utils.py
+++ b/test/utils.py
@@ -167,6 +167,7 @@ def do_test_full_package(module_dir, output_path='output', pkg_name='full_packag
         'changelog',
         'full ros2 test package',  # the package description
         'links',
+        'rclcpp',  # a ros package dependency
     ]
     file_includes = [
         'generated/index.html'
@@ -178,9 +179,11 @@ def do_test_full_package(module_dir, output_path='output', pkg_name='full_packag
         '__standards.html',
         'https://example.com/repo',
         'PACKAGE.html',  # package.xml
+        'https://docs.ros.org/en/rolling/p/rclpy/',  # a link to a package dependency
     ]
     excludes = [
-        'dontshowme'
+        'dontshowme',
+        'eigen',  # This is a system dependency, not a ros package.
     ]
     fragments = [
         ('index.html', 'this is the package readme.'),


### PR DESCRIPTION
Generated-by: Portions of this commit may include code completion from github.copilot version 1.372.0 or later

Replaces #114 

As requested in #114, rather than detect meta packages and add dependencies only to those, this PR adds exec dependencies for all packages.

Minor issue: I'm using the python rosdistro package to determine if an exec depend is a ros package or a system dependency. Because typical documentation builds of packages rely on scanning a repo for packages, unreleased packages get added to the rosdoc2 output listing. But when those packages are scanned for exec_depends, if those packages are not released, they will not show up as ros package dependencies.

A current example of this is http://docs.ros.org/en/rolling/p/turtlebot3_applications/  This has ros package depends including turtlebot3_automatic_parking. But because that package is not released, it would not be listed in this PR as a Ros package dependency.

An earlier version that I did of this PR, rather than relying on the python package rosdistro to find valid ros packages, instead took the opposite approach of downloading rosdistro/rosdep and then excluding known system packages from the listed ros package dependencies. That would then work for unreleased ros packages, but was considerably slower than the rosdistro-based approach. 