### PR TITLE
Expand mocking of python variables to fix 1) -pip ending, 2) replace "-" with "_"

### DIFF
--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -271,7 +271,7 @@ if rosdoc2_settings.get('enable_autodoc', True):
     for exec_depend in {exec_depends}:
         try:
             # Some python dependencies may be dist packages.
-            exec_depend = exec_depend.split("python3-")[-1]
+            exec_depend = exec_depend.split("python3-")[-1].split("-pip")[0].replace('-', '_')
             importlib.import_module(exec_depend)
         except ImportError:
             pkgs_to_mock.append(exec_depend)

--- a/test/packages/only_python/README.txt
+++ b/test/packages/only_python/README.txt
@@ -1,1 +1,6 @@
 This is a README as simple text.
+
+This tests a python-only package of type ament-python.
+
+It also tests mocking: we manually add mocking of dummy_module in conf.py,
+and rosdoc2 automatically adds mocking of an exec_depend.

--- a/test/packages/only_python/only_python/python_node.py
+++ b/test/packages/only_python/only_python/python_node.py
@@ -1,4 +1,8 @@
-import dummy_module  # noqa: F401
+import dummy_module
+import test_of_automock
+
+test_of_automock.hello()
+dummy_module.goodbye()
 
 
 def main():

--- a/test/packages/only_python/package.xml
+++ b/test/packages/only_python/package.xml
@@ -12,6 +12,8 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
+  <exec_depend>python3-test-of-automock-pip</exec_depend>
+
   <export>
     <build_type>ament_python</build_type>
   </export>


### PR DESCRIPTION
Fixes #200

Generated-by: Portions of this commit may include code completion from github.copilot version 1.372.0 or later

Python modules need to be mocked if they are imported into python files. Although not ideal, rosdoc2 tries to automate this process by parsing the rosdep key and trying to guess the python module. This PR adds two additional categories to the guess: remove any '-pip' at the end, and replace hyphens with underscores.

There are additional, unfixed reasons why the automatic mocking might fail, but this is still a net improvement.