### PR TITLE
Choose a testing theme that is available in Ubuntu

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ test =
     flake8-quotes
     pytest
     sphinx-prompt  # only needed to test detection of installed extensions.
-    plone-sphinx-theme  # only needed to test detection of installed themes.
+    sphinx-book-theme  # only needed to test detection of installed themes.
 
 [options.package_data]
 * = *.jinja

--- a/test/packages/rclcpp/doc/conf.py
+++ b/test/packages/rclcpp/doc/conf.py
@@ -79,7 +79,7 @@ source_suffix = {
 # a list of builtin themes.
 #
 # In tests, this theme is installed, but will not be used since 'override_theme' = True,
-html_theme = 'plone_sphinx_theme'
+html_theme = 'sphinx_book_theme'
 
 html_theme_options = {
     # Toc options. The default theme seems to require at least this to be set:

--- a/test/packages/src_python/doc/source/conf.py
+++ b/test/packages/src_python/doc/source/conf.py
@@ -85,7 +85,7 @@ source_suffix = {
 
 # This tests using a different theme, since 'override_theme' = False.  Note we don't
 # have to install the extension in Sphinx for the theme to be found.
-html_theme = 'plone_sphinx_theme'
+html_theme = 'sphinx_book_theme'
 
 html_theme_options = { 'i_do_not_exist': 1 }
 


### PR DESCRIPTION
For running tests on this package, we should choose a theme for testing which is available on Ubuntu as a deb package.