### PR TITLE
Reorder inclusion of extra_doxyfile_statements so we can override rosdoc2_doxyfile_statements

### DIFF
--- a/rosdoc2/verbs/build/builders/doxygen_builder.py
+++ b/rosdoc2/verbs/build/builders/doxygen_builder.py
@@ -49,11 +49,11 @@ EXTENDED_DOXYFILE = """\
 ## Include the user defined, or default if none specified, Doxyfile.
 @INCLUDE = {doxyfile_file_name}
 
-## Add extra doxyfile statements given by the user.
-{extra_doxyfile_statements}
-
 ## Add rosdoc2 doxyfile statements for tag files, output directory, etc.
 {rosdoc2_doxyfile_statements}
+
+## Add extra doxyfile statements given by the user.
+{extra_doxyfile_statements}
 """
 
 


### PR DESCRIPTION
Generated-by: Portions of this commit may include code completion from github.copilot version 1.372.0 or later

This issue is briefly discussed in #204 but let me try to elaborate.

It turns out that the included TAGFILES can have a significant effect on what is or is not documented by Doxygen, and by implication the breathe/exhale documentation that we use. This is particularly sensitive to Namespace. What TAGFILES are included, and how and whether that namespace is documented in various packages, can affect whether you see: 1) only the new functions and methods in a namespace in a package, or 2) nothing in the namespace, or 3) the entire namespace (albeit with broken documentation) including from other packages. All TAGFILES currently seen by rosdoc2 are currently included, which depends on the uncontrolled order that packages are built.

geometry2, with its shared namespace definitions for tf2, suffers somewhat from this. Example: in tf2, you have [Function tf2::fromMsg(const geometry_msgs::msg::Pose&, Eigen::Affine3d&)](http://docs.ros.org/en/kilted/p/tf2/generated/function_namespacetf2_1ac8166510f6b4bc4644176d49ea89a217.html#exhale-function-namespacetf2-1ac8166510f6b4bc4644176d49ea89a217) as well as in tf2 eigen as [Function tf2::fromMsg(const geometry_msgs::msg::Pose&, Eigen::Affine3d&)](http://docs.ros.org/en/kilted/p/tf2_eigen/generated/function_namespacetf2_1ac8166510f6b4bc4644176d49ea89a217.html#exhale-function-namespacetf2-1ac8166510f6b4bc4644176d49ea89a217)  But the one in tf2 is partly broken without the details, while the one in tf2_eigen is correct.  Perhaps a worse problem is that the documentation of namespace tf2 in tf2_eigen includes all of the functions defined in tf2, but with broken definitions.

There are a few fixes I have planned to address this, but ultimately I need to be able to disable automatic usage of found TAGFILES in packages. The current design of rosdoc2 prevents this, as though you can add extra doxyfile statements, they get overridden by the generated statements.

This PR simple reverses the order, so that extra_doxyfile_statements can override the defaults. extra_doxyfile_statements is a very rarely used feature, so I doubt this will affect anyone.