### PR TITLE
Move optional C++ (Doxygen) to after standard C++ line

### DIFF
--- a/rosdoc2/verbs/build/builders/index.rst.jinja
+++ b/rosdoc2/verbs/build/builders/index.rst.jinja
@@ -5,7 +5,6 @@
 
 {{ package.description }}
 
-{% if show_doxygen_html and has_cpp %}* `C++ API (Doxygen) <generated/doxygen/html/>`_{% endif %}
 
 .. toctree::
    :maxdepth: 2
@@ -13,6 +12,11 @@
    Links <__links>
 {% if has_python %}   Python API <modules>{% endif %}
 {% if has_cpp and not disable_breathe %}   C++ API <generated/index>{% endif %}
+
+{% if show_doxygen_html and has_cpp %}* `C++ API (Doxygen) <generated/doxygen/html/>`_{% endif %}
+.. toctree::
+   :maxdepth: 2
+
 {% if interface_counts['msg'] > 0 %}   Message Definitions <__message_definitions>{% endif %}
 {% if interface_counts['srv'] > 0 %}   Service Definitions <__service_definitions>{% endif %}
 {% if interface_counts['action'] > 0 %}   Action Definitions <__action_definitions>{% endif %}


### PR DESCRIPTION
Generated-by: Portions of this commit may include code completion from github.copilot version 1.372.0 or later

This small change is because, when I considered enabling doxygen output on a package (specifically tf2), the Doxygen link was too prominent at the top of the page. We want it a little more subtle, after the standard C++ documentation.

It still appears at the top of the TOC on the left, not sure how to change that.