### PR TITLE
Only add doxygen tags and intersphinx for packages we depend on

### DIFF
--- a/rosdoc2/verbs/build/builders/doxygen_builder.py
+++ b/rosdoc2/verbs/build/builders/doxygen_builder.py
@@ -244,7 +244,11 @@ class DoxygenBuilder(Builder):
         self.rosdoc2_doxyfile_statements.append(f'GENERATE_TAGFILE = {tag_file_name}')
 
         # Add entries for tag files found in the cross-reference directory.
-        tag_files = collect_tag_files(self.build_context.tool_options.cross_reference_directory)
+        package = self.build_context.package
+        tag_files = collect_tag_files(
+            self.build_context.tool_options.cross_reference_directory,
+            [d.name for d in package.exec_depends + package.doc_depends]
+        )
         base_url = self.build_context.tool_options.base_url
         tag_file_entries = [
             f'TAGFILES += "{os.path.abspath(tagfile_dict["tag_file"])}'

--- a/rosdoc2/verbs/build/builders/sphinx_builder.py
+++ b/rosdoc2/verbs/build/builders/sphinx_builder.py
@@ -511,7 +511,8 @@ class SphinxBuilder(Builder):
                         f"Error the 'doxygen_xml_directory' specified "
                         f"'{self.doxygen_xml_directory}' does not exist.")
 
-        package_xml_directory = os.path.dirname(self.build_context.package.filename)
+        package = self.build_context.package
+        package_xml_directory = os.path.dirname(package.filename)
         # If 'python_source' is specified, construct 'python_src_directory' from it
         python_src_directory = None
         if self.build_context.python_source is not None:
@@ -606,7 +607,10 @@ class SphinxBuilder(Builder):
 
         # Collect intersphinx mapping extensions from discovered inventory files.
         inventory_files = \
-            collect_inventory_files(self.build_context.tool_options.cross_reference_directory)
+            collect_inventory_files(
+                self.build_context.tool_options.cross_reference_directory,
+                [d.name for d in package.exec_depends + package.doc_depends]
+            )
         base_url = self.build_context.tool_options.base_url
         intersphinx_mapping_extensions = [
             f"'{package_name}': "
@@ -618,7 +622,7 @@ class SphinxBuilder(Builder):
         ]
 
         # Collect package-only exec_depends
-        exec_depends = self.build_context.package.exec_depends
+        exec_depends = package.exec_depends
         ros_distro = os.environ.get('ROS_DISTRO')
         if not ros_distro:
             logger.warning('ROS_DISTRO not set, cannot check ros package dependencies')
@@ -671,7 +675,6 @@ class SphinxBuilder(Builder):
                         'therefore using a default Sphinx configuration.')
 
         breathe_projects = []
-        package = self.build_context.package
 
         if self.doxygen_xml_directory is not None:
             breathe_projects.append(

--- a/rosdoc2/verbs/build/collect_inventory_files.py
+++ b/rosdoc2/verbs/build/collect_inventory_files.py
@@ -19,7 +19,7 @@ import os
 logger = logging.getLogger('rosdoc2')
 
 
-def collect_inventory_files(cross_reference_directory):
+def collect_inventory_files(cross_reference_directory, depends):
     """
     Collect all inventory files of a given cross reference directory.
 
@@ -35,6 +35,9 @@ def collect_inventory_files(cross_reference_directory):
                     raise RuntimeError(
                         f"unexpectedly got duplicate tag file for package '{package_name}'"
                     )
+                # only include if in depends list
+                if package_name not in depends:
+                    continue
                 inventory_file_path = os.path.join(root, filename)
                 location_json_path = inventory_file_path + '.location.json'
                 if not os.path.exists(location_json_path):

--- a/rosdoc2/verbs/build/collect_tag_files.py
+++ b/rosdoc2/verbs/build/collect_tag_files.py
@@ -19,13 +19,16 @@ import os
 logger = logging.getLogger('rosdoc2')
 
 
-def collect_tag_files(cross_reference_directory):
+def collect_tag_files(cross_reference_directory, depends):
     """Collect all tag files if a given cross reference directory."""
     tag_files = {}
     for root, directories, filenames in os.walk(cross_reference_directory):
         for filename in filenames:
             filename_base, filename_ext = os.path.splitext(filename)
             if filename_ext == '.tag':
+                if filename_base not in depends:
+                    # Only include tag files for packages we depend on.
+                    continue
                 # The filename_base should be a package name.
                 if filename_base in tag_files:
                     raise RuntimeError(


### PR DESCRIPTION
Generated-by: Portions of this commit may include code completion from github.copilot version 1.372.0 or later

Presently, rosdoc2 will include doxygen tag files, and intersphinx object.inv files, for any files it finds in the cross-reference directory. When running rosdoc2 in cases where there are a lot of pre-existing cross reference files, this can slow things down considerably as hundreds of cross references must be processed. In addition, it creates a dependency on order of execution, which can be problematic as doxygen results can change significantly depending on the available tagfiles, not only in cross references but also in what it chooses to document.

This PR only includes .tag and object.inv files for packages that exist in the exec_depends for a package. I believe this captures all of the important cross-references, without including unneeded ones.

This partially solves the dependency on execution issue. An upcoming PR will modify 'rosdoc2 scan' to process packages in dependency order. This should allow a single run of 'rosdoc2 scan' to generate needed cross-references for an entire ROS distro repository (which runs in a couple of hours on my computer). That could be implemented on the buildfarm in the future to get cross-references finally enabled.

